### PR TITLE
feat: add fetch_url tool and AbortSignal support for chat requests

### DIFF
--- a/src/chat/processCompletion.ts
+++ b/src/chat/processCompletion.ts
@@ -10,6 +10,7 @@ const processCompletion = async (
   tools: QPTool[],
   initialSystemMessage: string,
   toolExecutionContext: ToolExecutionContext,
+  signal?: AbortSignal,
 ): Promise<ChatMessage[]> => {
   const request: CompletionRequest = {
     model: chat.model,
@@ -35,6 +36,7 @@ const processCompletion = async (
     method: "POST",
     headers,
     body: JSON.stringify(request),
+    signal,
   });
 
   if (!response.ok) {
@@ -120,6 +122,7 @@ const processCompletion = async (
       tools,
       initialSystemMessage,
       toolExecutionContext,
+      signal,
     );
 
     return [...ret, ...x];

--- a/src/chat/tools/fetchUrl.ts
+++ b/src/chat/tools/fetchUrl.ts
@@ -1,0 +1,228 @@
+import { QPTool, ToolExecutionContext } from "../types";
+
+/**
+ * A tool that allows the AI to fetch content from external URLs.
+ * This addresses the hallucination issue where the AI would fabricate
+ * metadata instead of actually retrieving it from external sources.
+ */
+
+// List of allowed domains to prevent misuse
+const ALLOWED_DOMAINS = [
+  "elifesciences.org",
+  "doi.org",
+  "pubmed.ncbi.nlm.nih.gov",
+  "ncbi.nlm.nih.gov",
+  "biorxiv.org",
+  "medrxiv.org",
+  "arxiv.org",
+  "nature.com",
+  "science.org",
+  "cell.com",
+  "pnas.org",
+  "plos.org",
+  "frontiersin.org",
+  "springer.com",
+  "wiley.com",
+  "sciencedirect.com",
+  "nih.gov",
+  "github.com",
+  "dandiarchive.org",
+  "wikipedia.org",
+  "crossref.org",
+];
+
+const isUrlAllowed = (url: string): boolean => {
+  try {
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname.toLowerCase();
+    return ALLOWED_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith("." + domain)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const fetchUrlTool: QPTool = {
+  toolFunction: {
+    name: "fetch_url",
+    description:
+      "Fetch content from an external URL to retrieve information. Use this tool when you need to get data from a scientific article, publication, or other external resource. The content will be returned as text that you can then analyze to extract relevant metadata.",
+    parameters: {
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+          description:
+            "The URL to fetch content from. Must be a valid URL from an allowed domain (scientific publications, DOI resolvers, etc.).",
+        },
+        reason: {
+          type: "string",
+          description:
+            "A brief explanation of why you need to fetch this URL and what information you're looking for.",
+        },
+      },
+      required: ["url"],
+    },
+  },
+
+  execute: async (
+    params: { url: string; reason?: string },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _context: ToolExecutionContext
+  ) => {
+    const { url, reason } = params;
+
+    // Validate URL format
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return {
+        result: JSON.stringify({
+          success: false,
+          error: `Invalid URL format: "${url}". Please provide a valid URL.`,
+        }),
+      };
+    }
+
+    // Check if the domain is allowed
+    if (!isUrlAllowed(url)) {
+      return {
+        result: JSON.stringify({
+          success: false,
+          error: `Domain not allowed: "${parsedUrl.hostname}". For security reasons, only URLs from allowed scientific publication domains can be fetched. Allowed domains include: ${ALLOWED_DOMAINS.slice(0, 10).join(", ")}, and others.`,
+        }),
+      };
+    }
+
+    try {
+      // Use a CORS proxy to fetch the content since this runs in the browser
+      // We'll use a simple approach that works for most scientific publications
+      const proxyUrl = `https://corsproxy.io/?${encodeURIComponent(url)}`;
+
+      const response = await fetch(proxyUrl, {
+        method: "GET",
+        headers: {
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "User-Agent": "DandisetMetadataAssistant/1.0",
+        },
+      });
+
+      if (!response.ok) {
+        return {
+          result: JSON.stringify({
+            success: false,
+            error: `Failed to fetch URL: HTTP ${response.status} ${response.statusText}`,
+            url,
+          }),
+        };
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      let content: string;
+
+      if (contentType.includes("application/json")) {
+        const json = await response.json();
+        content = JSON.stringify(json, null, 2);
+      } else {
+        // For HTML/text content, get the raw text
+        const html = await response.text();
+        // Extract meaningful text from HTML, removing scripts and styles
+        content = extractTextFromHtml(html);
+      }
+
+      // Truncate if too long (to avoid overwhelming the context)
+      const maxLength = 15000;
+      const truncated = content.length > maxLength;
+      const finalContent = truncated
+        ? content.substring(0, maxLength) + "\n\n[Content truncated due to length...]"
+        : content;
+
+      return {
+        result: JSON.stringify({
+          success: true,
+          url,
+          reason: reason || "Not specified",
+          contentLength: content.length,
+          truncated,
+          content: finalContent,
+        }),
+      };
+    } catch (error) {
+      return {
+        result: JSON.stringify({
+          success: false,
+          error: `Error fetching URL: ${error instanceof Error ? error.message : "Unknown error"}`,
+          url,
+          hint: "The URL might be inaccessible, blocked by CORS, or the server might be down. Please verify the URL is correct.",
+        }),
+      };
+    }
+  },
+
+  getDetailedDescription: () => {
+    return `Use this tool to fetch content from external URLs when you need to retrieve information from scientific articles, publications, or other external resources.
+
+**IMPORTANT: Always use this tool when a user asks you to get information from an external URL. Never fabricate or hallucinate information - if you cannot fetch the URL, tell the user.**
+
+**Usage:**
+- Provide the URL you want to fetch
+- Optionally explain why you need to fetch it
+
+**Allowed domains:**
+This tool only works with approved scientific/academic domains including:
+- Scientific journals (eLife, Nature, Science, Cell, PNAS, PLOS, etc.)
+- Preprint servers (bioRxiv, medRxiv, arXiv)
+- DOI resolvers (doi.org)
+- PubMed/NIH resources
+- GitHub, DANDI Archive, Wikipedia
+
+**Examples:**
+- Fetch an eLife article: { "url": "https://elifesciences.org/articles/78362", "reason": "To extract metadata for the dandiset" }
+- Resolve a DOI: { "url": "https://doi.org/10.7554/eLife.78362", "reason": "To get publication details" }
+
+**Notes:**
+- Content is returned as text extracted from the webpage
+- Very long content will be truncated
+- If fetching fails, an error message will explain why
+- Always verify the fetched content before using it to propose metadata changes`;
+  },
+};
+
+/**
+ * Extract readable text from HTML, removing scripts, styles, and excessive whitespace
+ */
+function extractTextFromHtml(html: string): string {
+  // Remove script and style elements
+  let text = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ");
+  text = text.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ");
+
+  // Remove HTML comments
+  text = text.replace(/<!--[\s\S]*?-->/g, " ");
+
+  // Remove HTML tags but keep their content
+  text = text.replace(/<[^>]+>/g, " ");
+
+  // Decode common HTML entities
+  text = text.replace(/&nbsp;/g, " ");
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&rsquo;/g, "'");
+  text = text.replace(/&lsquo;/g, "'");
+  text = text.replace(/&rdquo;/g, '"');
+  text = text.replace(/&ldquo;/g, '"');
+  text = text.replace(/&mdash;/g, "—");
+  text = text.replace(/&ndash;/g, "–");
+
+  // Collapse multiple whitespace characters into single spaces
+  text = text.replace(/\s+/g, " ");
+
+  // Trim
+  text = text.trim();
+
+  return text;
+}

--- a/src/chat/tools/proposeMetadataChange.ts
+++ b/src/chat/tools/proposeMetadataChange.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { QPTool, ToolExecutionContext } from "../types";
+import {
+  validateMetadataChange,
+  formatValidationErrors,
+} from "../../schemas/validateMetadata";
 
 /**
  * Helper function to get a value at a path in an object using dot notation
@@ -81,6 +85,19 @@ export const proposeMetadataChangeTool: QPTool = {
           }),
         };
       }
+    }
+
+    // Validate the proposed change against the DANDI schema
+    const validationResult = validateMetadataChange(path, newValue, metadata);
+    if (!validationResult.valid) {
+      const errorMessage = formatValidationErrors(validationResult.errors);
+      return {
+        result: JSON.stringify({
+          success: false,
+          error: `Schema validation failed: ${errorMessage}`,
+          validationErrors: validationResult.errors,
+        }),
+      };
     }
 
     // Add the pending change

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -1,16 +1,19 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import {
   Box,
+  CircularProgress,
   Typography,
   IconButton,
   Paper,
   Alert,
   Chip,
   Tooltip,
+  Button,
 } from "@mui/material";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 import SettingsIcon from "@mui/icons-material/Settings";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import StopIcon from "@mui/icons-material/Stop";
 import { useMetadataContext } from "../../context/MetadataContext";
 import useChat from "../../chat/useChat";
 import { CHEAP_MODELS } from "../../chat/availableModels";
@@ -40,6 +43,7 @@ export function ChatPanel() {
     setChatModel,
     error,
     clearChat,
+    abortResponse,
   } = useChat({
     getMetadata,
     addPendingChange,
@@ -117,6 +121,18 @@ export function ChatPanel() {
           Assistant
         </Typography>
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          {responding && (
+            <Button
+              size="small"
+              variant="outlined"
+              color="error"
+              startIcon={<StopIcon />}
+              onClick={abortResponse}
+              sx={{ mr: 1 }}
+            >
+              Stop
+            </Button>
+          )}
           <Chip
             label={chat.model.split("/")[1]}
             size="small"
@@ -235,12 +251,15 @@ export function ChatPanel() {
                     borderTopLeftRadius: 0,
                   }}
                 >
-                  <Typography
-                    variant="body2"
-                    sx={{ fontStyle: "italic", color: "text.secondary" }}
-                  >
-                    Thinking...
-                  </Typography>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    <CircularProgress size={16} />
+                    <Typography
+                      variant="body2"
+                      sx={{ fontStyle: "italic", color: "text.secondary" }}
+                    >
+                      Thinking...
+                    </Typography>
+                  </Box>
                 </Paper>
               </Box>
             )}

--- a/src/components/Chat/MessageItem.tsx
+++ b/src/components/Chat/MessageItem.tsx
@@ -1,8 +1,10 @@
-import { FunctionComponent } from "react";
-import { Box, Paper, Typography, Chip } from "@mui/material";
+import { FunctionComponent, useState } from "react";
+import { Box, CircularProgress, Collapse, IconButton, Paper, Typography } from "@mui/material";
 import PersonIcon from "@mui/icons-material/Person";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 import BuildIcon from "@mui/icons-material/Build";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import MarkdownContent from "./MarkdownContent";
 import { ChatMessage, ORContentPart } from "../../chat/types";
 
@@ -24,6 +26,274 @@ const messageContentToString = (
       else return "";
     })
     .join("\n");
+};
+
+/**
+ * Get a short summary for a tool call based on its name and arguments
+ */
+const getToolCallSummary = (
+  name: string,
+  argsString: string
+): string => {
+  try {
+    const args = JSON.parse(argsString);
+    switch (name) {
+      case "fetch_url":
+        return args.url ? `fetch_url: ${args.url}` : "fetch_url";
+      case "propose_metadata_change":
+        return args.path ? `propose_metadata_change: ${args.path}` : "propose_metadata_change";
+      default:
+        return name;
+    }
+  } catch {
+    return name;
+  }
+};
+
+/**
+ * Expandable tool call component
+ */
+interface ToolCallItemProps {
+  name: string;
+  argsString: string;
+  inProgress: boolean;
+}
+
+const ToolCallItem: FunctionComponent<ToolCallItemProps> = ({
+  name,
+  argsString,
+  inProgress,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const summary = getToolCallSummary(name, argsString);
+
+  let formattedArgs = argsString;
+  try {
+    formattedArgs = JSON.stringify(JSON.parse(argsString), null, 2);
+  } catch {
+    // Keep original if not valid JSON
+  }
+
+  return (
+    <Box sx={{ mb: 0.5 }}>
+      <Box
+        onClick={() => setExpanded(!expanded)}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          px: 1,
+          py: 0.5,
+          borderRadius: 1,
+          border: 1,
+          borderColor: inProgress ? "warning.main" : "success.main",
+          backgroundColor: inProgress ? "warning.lighter" : "success.lighter",
+          cursor: "pointer",
+          "&:hover": {
+            backgroundColor: inProgress ? "warning.light" : "success.light",
+          },
+          transition: "background-color 0.2s",
+        }}
+      >
+        <BuildIcon
+          sx={{
+            fontSize: 16,
+            color: inProgress ? "warning.dark" : "success.dark",
+          }}
+        />
+        <Typography
+          variant="body2"
+          sx={{
+            color: inProgress ? "warning.dark" : "success.dark",
+            fontFamily: "monospace",
+            fontSize: "0.8rem",
+          }}
+        >
+          {inProgress ? "Calling" : "Called"}: {summary}
+        </Typography>
+        <IconButton
+          size="small"
+          sx={{
+            p: 0,
+            ml: 0.5,
+            color: inProgress ? "warning.dark" : "success.dark",
+          }}
+        >
+          {expanded ? (
+            <ExpandLessIcon sx={{ fontSize: 16 }} />
+          ) : (
+            <ExpandMoreIcon sx={{ fontSize: 16 }} />
+          )}
+        </IconButton>
+      </Box>
+      <Collapse in={expanded}>
+        <Box
+          sx={{
+            mt: 0.5,
+            ml: 2,
+            p: 1,
+            backgroundColor: "grey.50",
+            borderRadius: 1,
+            border: 1,
+            borderColor: "grey.300",
+            maxHeight: 200,
+            overflow: "auto",
+          }}
+        >
+          <Typography
+            component="pre"
+            variant="body2"
+            sx={{
+              fontFamily: "monospace",
+              fontSize: "0.75rem",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              m: 0,
+            }}
+          >
+            {formattedArgs}
+          </Typography>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+/**
+ * Truncate content for preview, showing first N characters
+ */
+const truncateContent = (content: string, maxLength: number = 150): string => {
+  if (content.length <= maxLength) return content;
+  return content.substring(0, maxLength).trim() + "...";
+};
+
+/**
+ * Tool result component with expandable content
+ */
+interface ToolResultItemProps {
+  message: ChatMessage & { role: "tool" };
+}
+
+const ToolResultItem: FunctionComponent<ToolResultItemProps> = ({ message }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  // Parse tool result for display
+  let resultContent = message.content;
+  let isSuccess = true;
+  let fullContent = message.content;
+
+  try {
+    const parsed = JSON.parse(message.content);
+    if (parsed.success !== undefined) {
+      isSuccess = parsed.success;
+      resultContent = parsed.message || parsed.error || message.content;
+      // For full content, show the entire parsed result nicely formatted
+      fullContent = JSON.stringify(parsed, null, 2);
+    }
+  } catch {
+    // Keep original content if not JSON
+  }
+
+  const isLongContent = resultContent.length > 150;
+  const previewContent = isLongContent ? truncateContent(resultContent) : resultContent;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "flex-start",
+        mb: 2,
+        pl: 4,
+      }}
+    >
+      <Paper
+        elevation={0}
+        sx={{
+          p: 1.5,
+          maxWidth: "75%",
+          backgroundColor: isSuccess ? "success.lighter" : "error.lighter",
+          border: 1,
+          borderColor: isSuccess ? "success.light" : "error.light",
+          borderRadius: 1,
+        }}
+      >
+        <Box
+          onClick={() => setExpanded(!expanded)}
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1,
+            cursor: "pointer",
+          }}
+        >
+          <BuildIcon
+            sx={{
+              fontSize: 16,
+              mt: 0.3,
+              color: isSuccess ? "success.main" : "error.main",
+            }}
+          />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                color: isSuccess ? "success.dark" : "error.dark",
+              }}
+            >
+              {expanded ? resultContent : previewContent}
+            </Typography>
+          </Box>
+          {isLongContent && (
+            <IconButton
+              size="small"
+              sx={{
+                p: 0,
+                color: isSuccess ? "success.dark" : "error.dark",
+              }}
+            >
+              {expanded ? (
+                <ExpandLessIcon sx={{ fontSize: 16 }} />
+              ) : (
+                <ExpandMoreIcon sx={{ fontSize: 16 }} />
+              )}
+            </IconButton>
+          )}
+        </Box>
+        {expanded && fullContent !== resultContent && (
+          <Collapse in={expanded}>
+            <Box
+              sx={{
+                mt: 1,
+                p: 1,
+                backgroundColor: "grey.50",
+                borderRadius: 1,
+                border: 1,
+                borderColor: "grey.300",
+                maxHeight: 300,
+                overflow: "auto",
+              }}
+            >
+              <Typography
+                component="pre"
+                variant="body2"
+                sx={{
+                  fontFamily: "monospace",
+                  fontSize: "0.75rem",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  m: 0,
+                }}
+              >
+                {fullContent}
+              </Typography>
+            </Box>
+          </Collapse>
+        )}
+      </Paper>
+    </Box>
+  );
 };
 
 const MessageItem: FunctionComponent<MessageItemProps> = ({
@@ -114,22 +384,22 @@ const MessageItem: FunctionComponent<MessageItemProps> = ({
               {hasToolCalls && (
                 <Box sx={{ mt: content ? 1 : 0 }}>
                   {message.tool_calls!.map((toolCall, index) => (
-                    <Chip
+                    <ToolCallItem
                       key={index}
-                      icon={<BuildIcon sx={{ fontSize: 16 }} />}
-                      label={`${inProgress ? "Calling" : "Called"}: ${toolCall.function.name}`}
-                      color={inProgress ? "warning" : "success"}
-                      size="small"
-                      variant="outlined"
-                      sx={{ mr: 1, mb: 0.5 }}
+                      name={toolCall.function.name}
+                      argsString={toolCall.function.arguments}
+                      inProgress={inProgress}
                     />
                   ))}
                 </Box>
               )}
               {inProgress && !content && !hasToolCalls && (
-                <Typography variant="body2" sx={{ fontStyle: "italic", color: "text.secondary" }}>
-                  Thinking...
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <CircularProgress size={16} />
+                  <Typography variant="body2" sx={{ fontStyle: "italic", color: "text.secondary" }}>
+                    Thinking...
+                  </Typography>
+                </Box>
               )}
             </Box>
           </Box>
@@ -139,61 +409,7 @@ const MessageItem: FunctionComponent<MessageItemProps> = ({
   }
 
   if (message.role === "tool") {
-    // Parse tool result for display
-    let resultContent = message.content;
-    let isSuccess = true;
-    try {
-      const parsed = JSON.parse(message.content);
-      if (parsed.success !== undefined) {
-        isSuccess = parsed.success;
-        resultContent = parsed.message || parsed.error || message.content;
-      }
-    } catch {
-      // Keep original content if not JSON
-    }
-
-    return (
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "flex-start",
-          mb: 2,
-          pl: 4,
-        }}
-      >
-        <Paper
-          elevation={0}
-          sx={{
-            p: 1.5,
-            maxWidth: "75%",
-            backgroundColor: isSuccess ? "success.lighter" : "error.lighter",
-            border: 1,
-            borderColor: isSuccess ? "success.light" : "error.light",
-            borderRadius: 1,
-          }}
-        >
-          <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
-            <BuildIcon
-              sx={{
-                fontSize: 16,
-                mt: 0.3,
-                color: isSuccess ? "success.main" : "error.main",
-              }}
-            />
-            <Typography
-              variant="body2"
-              sx={{
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                color: isSuccess ? "success.dark" : "error.dark",
-              }}
-            >
-              {resultContent}
-            </Typography>
-          </Box>
-        </Paper>
-      </Box>
-    );
+    return <ToolResultItem message={message} />;
   }
 
   return null;

--- a/src/schemas/dandiset.schema.json
+++ b/src/schemas/dandiset.schema.json
@@ -1,0 +1,2035 @@
+{
+  "$defs": {
+    "AccessRequirements": {
+      "description": "Information about access options for the dataset",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "AccessRequirements",
+          "default": "AccessRequirements",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/AccessType",
+          "description": "The access status of the item.",
+          "nskey": "dandi",
+          "title": "Access status"
+        },
+        "contactPoint": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContactPoint"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Who or where to look for information about access.",
+          "nskey": "schema",
+          "title": "Contact Point",
+          "type": "object"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Information about access requirements when embargoed or restricted",
+          "nskey": "schema",
+          "title": "Description"
+        },
+        "embargoedUntil": {
+          "anyOf": [
+            {
+              "format": "date",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date on which embargo ends.",
+          "nskey": "dandi",
+          "rangeIncludes": "schema:Date",
+          "readOnly": true,
+          "title": "Embargo end date"
+        }
+      },
+      "required": [
+        "schemaKey",
+        "status"
+      ],
+      "title": "Access Requirements",
+      "type": "object"
+    },
+    "AccessType": {
+      "description": "An enumeration of access status options",
+      "enum": [
+        "dandi:OpenAccess",
+        "dandi:EmbargoedAccess"
+      ],
+      "title": "AccessType",
+      "type": "string"
+    },
+    "Affiliation": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Affiliation",
+          "default": "Affiliation",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "pattern": "^https://ror.org/[a-z0-9]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Use an ror.org identifier for institutions.",
+          "nskey": "schema",
+          "title": "A ror.org identifier"
+        },
+        "name": {
+          "description": "Name of organization",
+          "nskey": "schema",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey"
+      ],
+      "title": "Affiliation",
+      "type": "object"
+    },
+    "Agent": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Agent",
+          "default": "Agent",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Identifier for an agent.",
+          "nskey": "schema",
+          "title": "Identifier"
+        },
+        "name": {
+          "nskey": "schema",
+          "title": "Name",
+          "type": "string"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "URL"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey"
+      ],
+      "title": "Agent",
+      "type": "object"
+    },
+    "Anatomy": {
+      "description": "UBERON or other identifier for anatomical part studied",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Anatomy",
+          "default": "Anatomy",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Anatomy",
+      "type": "object"
+    },
+    "ApproachType": {
+      "description": "Identifier for approach used",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "ApproachType",
+          "default": "ApproachType",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Approach Type",
+      "type": "object"
+    },
+    "AssetsSummary": {
+      "description": "Summary over assets contained in a dandiset (published or not)",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "AssetsSummary",
+          "default": "AssetsSummary",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "numberOfBytes": {
+          "readOnly": true,
+          "sameas": "schema:contentSize",
+          "title": "Number of Bytes",
+          "type": "integer"
+        },
+        "numberOfFiles": {
+          "readOnly": true,
+          "title": "Number of Files",
+          "type": "integer"
+        },
+        "numberOfSubjects": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Number of Subjects"
+        },
+        "numberOfSamples": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Number of Samples"
+        },
+        "numberOfCells": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Number of Cells"
+        },
+        "dataStandard": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/StandardsType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Data Standard"
+        },
+        "approach": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ApproachType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Approach"
+        },
+        "measurementTechnique": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/MeasurementTechniqueType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "readOnly": true,
+          "title": "Measurement Technique"
+        },
+        "variableMeasured": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "readOnly": true,
+          "title": "Variable Measured"
+        },
+        "species": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/SpeciesType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "readOnly": true,
+          "title": "Species"
+        }
+      },
+      "required": [
+        "numberOfBytes",
+        "numberOfFiles",
+        "schemaKey"
+      ],
+      "title": "Assets Summary",
+      "type": "object"
+    },
+    "ContactPoint": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "ContactPoint",
+          "default": "ContactPoint",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "format": "email",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Email address of contact.",
+          "nskey": "schema",
+          "title": "Email"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A Web page to find information on how to contact.",
+          "nskey": "schema",
+          "title": "URL"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Contact Point",
+      "type": "object"
+    },
+    "Disorder": {
+      "description": "Biolink, SNOMED, or other identifier for disorder studied",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Disorder",
+          "default": "Disorder",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        },
+        "dxdate": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "format": "date-time",
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Dates of diagnosis",
+          "nskey": "dandi",
+          "rangeIncludes": "schema:Date",
+          "title": "Dates of diagnosis"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Disorder",
+      "type": "object"
+    },
+    "Equipment": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Equipment",
+          "default": "Equipment",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Identifier"
+        },
+        "name": {
+          "description": "A name for the equipment.",
+          "maxLength": 150,
+          "nskey": "schema",
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The description of the equipment.",
+          "nskey": "schema",
+          "title": "Description"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey"
+      ],
+      "title": "Equipment",
+      "type": "object"
+    },
+    "EthicsApproval": {
+      "description": "Information about ethics committee approval for project",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "EthicsApproval",
+          "default": "EthicsApproval",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Approved Protocol identifier, often a number or alphanumeric string.",
+          "nskey": "schema",
+          "title": "Approved protocol identifier",
+          "type": "string"
+        },
+        "contactPoint": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContactPoint"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Information about the ethics approval committee.",
+          "nskey": "schema",
+          "title": "Contact Point",
+          "type": "object"
+        }
+      },
+      "required": [
+        "identifier",
+        "schemaKey"
+      ],
+      "title": "Ethics Approval",
+      "type": "object"
+    },
+    "GenericType": {
+      "description": "An object to capture any type for about",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "GenericType",
+          "default": "GenericType",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Generic Type",
+      "type": "object"
+    },
+    "LicenseType": {
+      "description": "An enumeration of supported licenses",
+      "enum": [
+        "spdx:CC0-1.0",
+        "spdx:CC-BY-4.0"
+      ],
+      "title": "LicenseType",
+      "type": "string"
+    },
+    "MeasurementTechniqueType": {
+      "description": "Identifier for measurement technique used",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "MeasurementTechniqueType",
+          "default": "MeasurementTechniqueType",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Measurement Technique Type",
+      "type": "object"
+    },
+    "Organization": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Organization",
+          "default": "Organization",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "pattern": "^https://ror.org/[a-z0-9]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Use an ror.org identifier for institutions.",
+          "nskey": "schema",
+          "title": "A ror.org identifier"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Name"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "format": "email",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Email"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "URL"
+        },
+        "roleName": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/RoleType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Role(s) of the contributor. Multiple roles can be selected.",
+          "nskey": "schema",
+          "title": "Role"
+        },
+        "includeInCitation": {
+          "default": false,
+          "description": "A flag to indicate whether a contributor should be included when generating a citation for the item",
+          "nskey": "dandi",
+          "title": "Include contributor in citation",
+          "type": "boolean"
+        },
+        "awardNumber": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Identifier associated with a sponsored or gift award.",
+          "nskey": "dandi",
+          "title": "Identifier for an award"
+        },
+        "contactPoint": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ContactPoint"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Contact for the organization",
+          "nskey": "schema",
+          "title": "Organization contact information"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Organization",
+      "type": "object"
+    },
+    "Person": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Person",
+          "default": "Person",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "pattern": "^\\d{4}-\\d{4}-\\d{4}-(\\d{3}X|\\d{4})$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An ORCID (orcid.org) identifier for an individual.",
+          "nskey": "schema",
+          "title": "An ORCID identifier"
+        },
+        "name": {
+          "description": "Use the format: familyname, given names ...",
+          "nskey": "schema",
+          "title": "Use Last, First. Example: Lovelace, Augusta Ada",
+          "type": "string"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "format": "email",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Email"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "URL"
+        },
+        "roleName": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/RoleType"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Role(s) of the contributor. Multiple roles can be selected.",
+          "nskey": "schema",
+          "title": "Role"
+        },
+        "includeInCitation": {
+          "default": true,
+          "description": "A flag to indicate whether a contributor should be included when generating a citation for the item.",
+          "nskey": "dandi",
+          "title": "Include contributor in citation",
+          "type": "boolean"
+        },
+        "awardNumber": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Identifier associated with a sponsored or gift award.",
+          "nskey": "dandi",
+          "title": "Identifier for an award"
+        },
+        "affiliation": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Affiliation"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An organization that this person is affiliated with.",
+          "nskey": "schema",
+          "title": "Affiliation"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey"
+      ],
+      "title": "Person",
+      "type": "object"
+    },
+    "Project": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Project",
+          "default": "Project",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Identifier"
+        },
+        "name": {
+          "description": "The name of the project that generated this Dandiset or asset.",
+          "maxLength": 150,
+          "nskey": "schema",
+          "title": "Name of project",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A brief description of the project.",
+          "nskey": "schema",
+          "title": "Description"
+        },
+        "startDate": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Start Date"
+        },
+        "endDate": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "End Date"
+        },
+        "wasAssociatedWith": {
+          "anyOf": [
+            {
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "Agent": "#/$defs/Agent",
+                    "Organization": "#/$defs/Organization",
+                    "Person": "#/$defs/Person",
+                    "Software": "#/$defs/Software"
+                  },
+                  "propertyName": "schemaKey"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/Person"
+                  },
+                  {
+                    "$ref": "#/$defs/Organization"
+                  },
+                  {
+                    "$ref": "#/$defs/Software"
+                  },
+                  {
+                    "$ref": "#/$defs/Agent"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "prov",
+          "title": "Was Associated with"
+        },
+        "used": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Equipment"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A listing of equipment used for the activity.",
+          "nskey": "prov",
+          "title": "Used"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey"
+      ],
+      "title": "Project",
+      "type": "object"
+    },
+    "RelationType": {
+      "description": "An enumeration of resource relations",
+      "enum": [
+        "dcite:IsCitedBy",
+        "dcite:Cites",
+        "dcite:IsSupplementTo",
+        "dcite:IsSupplementedBy",
+        "dcite:IsContinuedBy",
+        "dcite:Continues",
+        "dcite:Describes",
+        "dcite:IsDescribedBy",
+        "dcite:HasMetadata",
+        "dcite:IsMetadataFor",
+        "dcite:HasVersion",
+        "dcite:IsVersionOf",
+        "dcite:IsNewVersionOf",
+        "dcite:IsPreviousVersionOf",
+        "dcite:IsPartOf",
+        "dcite:HasPart",
+        "dcite:IsReferencedBy",
+        "dcite:References",
+        "dcite:IsDocumentedBy",
+        "dcite:Documents",
+        "dcite:IsCompiledBy",
+        "dcite:Compiles",
+        "dcite:IsVariantFormOf",
+        "dcite:IsOriginalFormOf",
+        "dcite:IsIdenticalTo",
+        "dcite:IsReviewedBy",
+        "dcite:Reviews",
+        "dcite:IsDerivedFrom",
+        "dcite:IsSourceOf",
+        "dcite:IsRequiredBy",
+        "dcite:Requires",
+        "dcite:Obsoletes",
+        "dcite:IsObsoletedBy",
+        "dcite:IsPublishedIn"
+      ],
+      "title": "RelationType",
+      "type": "string"
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Resource",
+          "default": "Resource",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "Identifier"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "A title of the resource"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "nskey": "schema",
+          "title": "URL of the resource"
+        },
+        "repository": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the repository in which the resource is housed.",
+          "nskey": "dandi",
+          "title": "Name of the repository"
+        },
+        "relation": {
+          "$ref": "#/$defs/RelationType",
+          "description": "Indicates how the resource is related to the dataset. This relation should satisfy: dandiset <relation> resource.",
+          "nskey": "dandi",
+          "title": "Resource relation"
+        },
+        "resourceType": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The type of resource.",
+          "nskey": "dandi",
+          "title": "Resource type",
+          "type": "object"
+        }
+      },
+      "required": [
+        "relation",
+        "schemaKey"
+      ],
+      "title": "Resource",
+      "type": "object"
+    },
+    "ResourceType": {
+      "description": "An enumeration of resource types",
+      "enum": [
+        "dcite:Audiovisual",
+        "dcite:Book",
+        "dcite:BookChapter",
+        "dcite:Collection",
+        "dcite:ComputationalNotebook",
+        "dcite:ConferencePaper",
+        "dcite:ConferenceProceeding",
+        "dcite:DataPaper",
+        "dcite:Dataset",
+        "dcite:Dissertation",
+        "dcite:Event",
+        "dcite:Image",
+        "dcite:Instrument",
+        "dcite:InteractiveResource",
+        "dcite:Journal",
+        "dcite:JournalArticle",
+        "dcite:Model",
+        "dcite:OutputManagementPlan",
+        "dcite:PeerReview",
+        "dcite:PhysicalObject",
+        "dcite:Preprint",
+        "dcite:Report",
+        "dcite:Service",
+        "dcite:Software",
+        "dcite:Sound",
+        "dcite:Standard",
+        "dcite:StudyRegistration",
+        "dcite:Text",
+        "dcite:Workflow",
+        "dcite:Other"
+      ],
+      "title": "ResourceType",
+      "type": "string"
+    },
+    "RoleType": {
+      "description": "An enumeration of roles",
+      "enum": [
+        "dcite:Author",
+        "dcite:Conceptualization",
+        "dcite:ContactPerson",
+        "dcite:DataCollector",
+        "dcite:DataCurator",
+        "dcite:DataManager",
+        "dcite:FormalAnalysis",
+        "dcite:FundingAcquisition",
+        "dcite:Investigation",
+        "dcite:Maintainer",
+        "dcite:Methodology",
+        "dcite:Producer",
+        "dcite:ProjectLeader",
+        "dcite:ProjectManager",
+        "dcite:ProjectMember",
+        "dcite:ProjectAdministration",
+        "dcite:Researcher",
+        "dcite:Resources",
+        "dcite:Software",
+        "dcite:Supervision",
+        "dcite:Validation",
+        "dcite:Visualization",
+        "dcite:Funder",
+        "dcite:Sponsor",
+        "dcite:StudyParticipant",
+        "dcite:Affiliation",
+        "dcite:EthicsApproval",
+        "dcite:Other"
+      ],
+      "title": "RoleType",
+      "type": "string"
+    },
+    "Software": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "Software",
+          "default": "Software",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "pattern": "^RRID:.*",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "RRID of the software from scicrunch.org.",
+          "nskey": "schema",
+          "title": "Research resource identifier"
+        },
+        "name": {
+          "nskey": "schema",
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "nskey": "schema",
+          "title": "Version",
+          "type": "string"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Web page for the software.",
+          "nskey": "schema",
+          "title": "URL"
+        }
+      },
+      "required": [
+        "name",
+        "schemaKey",
+        "version"
+      ],
+      "title": "Software",
+      "type": "object"
+    },
+    "SpeciesType": {
+      "description": "Identifier for species of the sample",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "SpeciesType",
+          "default": "SpeciesType",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Species Type",
+      "type": "object"
+    },
+    "StandardsType": {
+      "description": "Identifier for data standard used",
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Uniform resource identifier",
+          "readOnly": true,
+          "title": "ID"
+        },
+        "schemaKey": {
+          "const": "StandardsType",
+          "default": "StandardsType",
+          "title": "Schema Key",
+          "type": "string"
+        },
+        "identifier": {
+          "default": null,
+          "description": "The identifier can be any url or a compact URI, preferably supported by identifiers.org.",
+          "format": "uri",
+          "maxLength": 1000,
+          "minLength": 1,
+          "nskey": "schema",
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "maxLength": 150,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the item.",
+          "nskey": "schema",
+          "title": "Name"
+        }
+      },
+      "required": [
+        "schemaKey"
+      ],
+      "title": "Standards Type",
+      "type": "object"
+    }
+  },
+  "additionalProperties": true,
+  "description": "A body of structured information describing a DANDI dataset.",
+  "properties": {
+    "id": {
+      "description": "Uniform resource identifier",
+      "pattern": "^(dandi|DANDI):\\d{6}(/(draft|\\d+\\.\\d+\\.\\d+))$",
+      "readOnly": true,
+      "title": "ID",
+      "type": "string"
+    },
+    "schemaKey": {
+      "const": "Dandiset",
+      "default": "Dandiset",
+      "title": "Schema Key",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "default": "0.6.10",
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "name": {
+      "description": "A title associated with the Dandiset.",
+      "maxLength": 150,
+      "nskey": "schema",
+      "title": "Dandiset title",
+      "type": "string"
+    },
+    "description": {
+      "description": "A description of the Dandiset",
+      "maxLength": 10000,
+      "nskey": "schema",
+      "title": "Description",
+      "type": "string"
+    },
+    "contributor": {
+      "description": "People or Organizations that have contributed to this Dandiset.",
+      "items": {
+        "discriminator": {
+          "mapping": {
+            "Organization": "#/$defs/Organization",
+            "Person": "#/$defs/Person"
+          },
+          "propertyName": "schemaKey"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/Person"
+          },
+          {
+            "$ref": "#/$defs/Organization"
+          }
+        ]
+      },
+      "minItems": 1,
+      "nskey": "schema",
+      "title": "Dandiset contributors",
+      "type": "array"
+    },
+    "about": {
+      "anyOf": [
+        {
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "Anatomy": "#/$defs/Anatomy",
+                "Disorder": "#/$defs/Disorder",
+                "GenericType": "#/$defs/GenericType"
+              },
+              "propertyName": "schemaKey"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/Disorder"
+              },
+              {
+                "$ref": "#/$defs/Anatomy"
+              },
+              {
+                "$ref": "#/$defs/GenericType"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The subject matter of the content, such as disorders, brain anatomy.",
+      "nskey": "schema",
+      "title": "Subject matter of the dataset"
+    },
+    "studyTarget": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Objectives or specific questions of the study.",
+      "nskey": "dandi",
+      "title": "Study Target"
+    },
+    "license": {
+      "description": "Licenses associated with the item. DANDI only supports a subset of Creative Commons Licenses (creativecommons.org) applicable to datasets.",
+      "items": {
+        "$ref": "#/$defs/LicenseType"
+      },
+      "minItems": 1,
+      "nskey": "schema",
+      "title": "License",
+      "type": "array"
+    },
+    "protocol": {
+      "anyOf": [
+        {
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "A list of persistent URLs describing the protocol (e.g. protocols.io, or other DOIs).",
+      "nskey": "dandi",
+      "title": "Protocol"
+    },
+    "ethicsApproval": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/EthicsApproval"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "nskey": "dandi",
+      "title": "Ethics approvals"
+    },
+    "keywords": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Keywords used to describe this content.",
+      "nskey": "schema",
+      "title": "Keywords"
+    },
+    "acknowledgement": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Any acknowledgments not covered by contributors or external resources.",
+      "nskey": "dandi",
+      "title": "Acknowledgement"
+    },
+    "access": {
+      "items": {
+        "$ref": "#/$defs/AccessRequirements"
+      },
+      "nskey": "dandi",
+      "readOnly": true,
+      "title": "Access information",
+      "type": "array"
+    },
+    "url": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "permalink to the item",
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "URL"
+    },
+    "repository": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "location of the item",
+      "nskey": "dandi",
+      "readOnly": true,
+      "title": "Repository"
+    },
+    "relatedResource": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "nskey": "dandi",
+      "title": "Related Resource"
+    },
+    "wasGeneratedBy": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Project"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Project(s) that generated this Dandiset.",
+      "nskey": "prov",
+      "title": "Associated projects"
+    },
+    "identifier": {
+      "description": "A Dandiset identifier that can be resolved by identifiers.org.",
+      "nskey": "schema",
+      "pattern": "^DANDI:\\d{6}$",
+      "readOnly": true,
+      "title": "Dandiset identifier",
+      "type": "string"
+    },
+    "dateCreated": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "Dandiset creation date and time."
+    },
+    "dateModified": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "Last modification date and time."
+    },
+    "citation": {
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "Citation",
+      "type": "string"
+    },
+    "assetsSummary": {
+      "$ref": "#/$defs/AssetsSummary",
+      "nskey": "dandi",
+      "readOnly": true,
+      "title": "Assets Summary"
+    },
+    "manifestLocation": {
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "nskey": "dandi",
+      "readOnly": true,
+      "title": "Manifest Location",
+      "type": "array"
+    },
+    "version": {
+      "nskey": "schema",
+      "readOnly": true,
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "assetsSummary",
+    "citation",
+    "contributor",
+    "description",
+    "id",
+    "identifier",
+    "license",
+    "manifestLocation",
+    "name",
+    "schemaKey",
+    "version"
+  ],
+  "title": "Dandiset",
+  "type": "object"
+}

--- a/src/schemas/validateMetadata.ts
+++ b/src/schemas/validateMetadata.ts
@@ -1,0 +1,287 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Ajv, { ErrorObject } from "ajv";
+import addFormats from "ajv-formats";
+import dandisetSchema from "./dandiset.schema.json";
+
+// Initialize AJV with the DANDI schema
+const ajv = new Ajv({
+  allErrors: true, // Report all errors, not just the first one
+  strict: false, // Allow additional keywords from Pydantic (nskey, etc.)
+  validateFormats: true,
+});
+
+// Add format validators (uri, email, date, etc.)
+addFormats(ajv);
+
+// Compile the full Dandiset schema
+const validateDandiset = ajv.compile(dandisetSchema);
+
+// Extract sub-schemas for individual field types from $defs
+const subSchemas: Record<string, any> = {};
+const defs = (dandisetSchema as any).$defs || {};
+
+// Pre-compile validators for common sub-schemas
+// We need to include the $defs in each sub-schema so $ref works
+for (const [name, schema] of Object.entries(defs)) {
+  try {
+    // Create a schema that includes all $defs so references resolve
+    const schemaWithDefs = {
+      ...(schema as any),
+      $defs: defs,
+    };
+    subSchemas[name] = ajv.compile(schemaWithDefs);
+  } catch (e) {
+    // Some schemas may still fail, skip them
+    console.warn(`Could not compile sub-schema for ${name}:`, e);
+  }
+}
+
+/**
+ * Validation result interface
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+export interface ValidationError {
+  path: string;
+  message: string;
+  keyword: string;
+  params?: Record<string, any>;
+}
+
+/**
+ * Convert AJV errors to a more user-friendly format
+ */
+function formatErrors(errors: ErrorObject[] | null | undefined): ValidationError[] {
+  if (!errors) return [];
+
+  return errors.map((err) => ({
+    path: err.instancePath || "/",
+    message: err.message || "Validation failed",
+    keyword: err.keyword,
+    params: err.params,
+  }));
+}
+
+/**
+ * Get the expected schema type for a given field path
+ * Returns the schema name (e.g., "Resource", "Person", "Organization")
+ */
+export function getSchemaTypeForPath(path: string): string | null {
+  // Map top-level fields to their schema types
+  const fieldTypeMap: Record<string, string> = {
+    relatedResource: "Resource",
+    contributor: "Person|Organization", // discriminated union
+    access: "AccessRequirements",
+    wasGeneratedBy: "Project",
+    about: "Disorder|Anatomy|GenericType",
+    ethicsApproval: "EthicsApproval",
+  };
+
+  // Get the root field name
+  const rootField = path.split(".")[0];
+
+  // Check if this is an array field with an index
+  if (fieldTypeMap[rootField]) {
+    return fieldTypeMap[rootField];
+  }
+
+  return null;
+}
+
+/**
+ * Validate a value against a specific sub-schema by name
+ */
+export function validateAgainstSubSchema(
+  schemaName: string,
+  value: any
+): ValidationResult {
+  const validator = subSchemas[schemaName];
+
+  if (!validator) {
+    // Schema not found - check if it's a union type
+    if (schemaName.includes("|")) {
+      const schemaNames = schemaName.split("|");
+      // Try each schema in the union
+      for (const name of schemaNames) {
+        const result = validateAgainstSubSchema(name.trim(), value);
+        if (result.valid) {
+          return result;
+        }
+      }
+      // None matched - return error
+      return {
+        valid: false,
+        errors: [
+          {
+            path: "/",
+            message: `Value must match one of: ${schemaName}`,
+            keyword: "oneOf",
+          },
+        ],
+      };
+    }
+
+    return {
+      valid: false,
+      errors: [
+        {
+          path: "/",
+          message: `Unknown schema type: ${schemaName}`,
+          keyword: "unknown",
+        },
+      ],
+    };
+  }
+
+  const valid = validator(value);
+  return {
+    valid: valid as boolean,
+    errors: formatErrors(validator.errors),
+  };
+}
+
+/**
+ * Validate a proposed metadata change
+ *
+ * @param path - The dot-notation path to the field being changed
+ * @param newValue - The proposed new value
+ * @param currentMetadata - The current full metadata object (optional, for context)
+ * @returns ValidationResult with valid flag and any errors
+ */
+export function validateMetadataChange(
+  path: string,
+  newValue: any,
+  currentMetadata?: any
+): ValidationResult {
+  // Determine if this is an array item or object field
+  const pathParts = path.split(".");
+  const rootField = pathParts[0];
+
+  // Check if we're setting an array element (e.g., relatedResource.0)
+  const isArrayElement = pathParts.length >= 2 && /^\d+$/.test(pathParts[1]);
+
+  if (isArrayElement) {
+    // Validate the array element against its schema type
+    const schemaType = getSchemaTypeForPath(path);
+
+    if (schemaType) {
+      // If the value is an object, validate against the sub-schema
+      if (typeof newValue === "object" && newValue !== null) {
+        return validateAgainstSubSchema(schemaType, newValue);
+      }
+    }
+  }
+
+  // For nested paths within an array element (e.g., relatedResource.0.name),
+  // we need to validate the full object after applying the change
+  if (pathParts.length > 2 && /^\d+$/.test(pathParts[1])) {
+    const schemaType = getSchemaTypeForPath(path);
+
+    if (schemaType && currentMetadata) {
+      // Get the current array element
+      const arrayIndex = parseInt(pathParts[1], 10);
+      const currentArray = currentMetadata[rootField] || [];
+      const currentElement = currentArray[arrayIndex] || {};
+
+      // Apply the change to create the new element
+      const newElement = applyNestedChange(
+        { ...currentElement },
+        pathParts.slice(2),
+        newValue
+      );
+
+      return validateAgainstSubSchema(schemaType, newElement);
+    }
+  }
+
+  // For top-level simple fields, validate against the full schema
+  // by creating a minimal object with just that field
+  if (pathParts.length === 1 && currentMetadata) {
+    const testMetadata = { ...currentMetadata, [rootField]: newValue };
+    const valid = validateDandiset(testMetadata);
+
+    if (!valid) {
+      // Filter errors to only those related to the changed field
+      const relevantErrors = (validateDandiset.errors || []).filter(
+        (err) =>
+          err.instancePath === `/${rootField}` ||
+          err.instancePath.startsWith(`/${rootField}/`)
+      );
+
+      if (relevantErrors.length > 0) {
+        return {
+          valid: false,
+          errors: formatErrors(relevantErrors),
+        };
+      }
+    }
+  }
+
+  // Default: validation passed (or couldn't be performed)
+  return { valid: true, errors: [] };
+}
+
+/**
+ * Helper to apply a nested change to an object
+ */
+function applyNestedChange(obj: any, pathParts: string[], value: any): any {
+  if (pathParts.length === 0) {
+    return value;
+  }
+
+  const [first, ...rest] = pathParts;
+  const isIndex = /^\d+$/.test(first);
+  const key = isIndex ? parseInt(first, 10) : first;
+
+  if (rest.length === 0) {
+    obj[key] = value;
+  } else {
+    if (obj[key] === undefined) {
+      obj[key] = isIndex ? [] : {};
+    }
+    obj[key] = applyNestedChange(obj[key], rest, value);
+  }
+
+  return obj;
+}
+
+/**
+ * Validate an entire metadata object against the Dandiset schema
+ */
+export function validateFullMetadata(metadata: any): ValidationResult {
+  const valid = validateDandiset(metadata);
+  return {
+    valid: valid as boolean,
+    errors: formatErrors(validateDandiset.errors),
+  };
+}
+
+/**
+ * Get a human-readable description of validation errors
+ */
+export function formatValidationErrors(errors: ValidationError[]): string {
+  if (errors.length === 0) return "";
+
+  return errors
+    .map((err) => {
+      let msg = err.message;
+
+      // Add more context based on error type
+      if (err.keyword === "enum" && err.params?.allowedValues) {
+        msg += `. Allowed values: ${err.params.allowedValues.join(", ")}`;
+      }
+      if (err.keyword === "required" && err.params?.missingProperty) {
+        msg = `Missing required property: ${err.params.missingProperty}`;
+      }
+      if (err.keyword === "additionalProperties" && err.params?.additionalProperty) {
+        msg = `Unknown property: ${err.params.additionalProperty}`;
+      }
+
+      const pathStr = err.path && err.path !== "/" ? ` at ${err.path}` : "";
+      return `${msg}${pathStr}`;
+    })
+    .join("; ");
+}


### PR DESCRIPTION
- Add new fetch_url tool to allow AI to retrieve content from external URLs instead of fabricating metadata (prevents hallucination)
- Implement domain allowlist for security (scientific publications, DOI resolvers, GitHub, Wikipedia, etc.)
- Add AbortSignal parameter to processCompletion for request cancellation
- Pass signal through fetch calls and recursive completion processing
- Validate schema on all changes