### PR TITLE
Redesign metadata panel with compact tabular layout

### DIFF
--- a/src/components/Metadata/ContributorsTable.tsx
+++ b/src/components/Metadata/ContributorsTable.tsx
@@ -1,0 +1,324 @@
+import { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  IconButton,
+  Tooltip,
+  Chip,
+  Box,
+  Collapse,
+} from '@mui/material';
+import UndoIcon from '@mui/icons-material/Undo';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import PersonIcon from '@mui/icons-material/Person';
+import BusinessIcon from '@mui/icons-material/Business';
+import { useMetadataContext } from '../../context/MetadataContext';
+import type { Contributor } from '../../types/dandiset';
+
+interface ContributorRowProps {
+  contributor: Contributor;
+  index: number;
+  hasChange: boolean;
+  hasChildChanges: boolean;
+  onRevert?: () => void;
+}
+
+function formatRoles(roles?: string[]): string[] {
+  if (!roles || roles.length === 0) return [];
+  return roles.map(role => role.replace('dcite:', ''));
+}
+
+function ContributorRow({ contributor, index, hasChange, hasChildChanges, onRevert }: ContributorRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { removePendingChange, getPendingChangeForPath } = useMetadataContext();
+
+  const isPerson = contributor.schemaKey === 'Person';
+  const showExpand = contributor.email || contributor.url || contributor.awardNumber || 
+                     (contributor.affiliation && contributor.affiliation.length > 0);
+
+  // Get pending changes for specific fields
+  const nameChange = getPendingChangeForPath(`contributor.${index}.name`);
+  const identifierChange = getPendingChangeForPath(`contributor.${index}.identifier`);
+  const rolesChange = getPendingChangeForPath(`contributor.${index}.roleName`);
+  const includeInCitationChange = getPendingChangeForPath(`contributor.${index}.includeInCitation`);
+  const emailChange = getPendingChangeForPath(`contributor.${index}.email`);
+  const urlChange = getPendingChangeForPath(`contributor.${index}.url`);
+  const awardNumberChange = getPendingChangeForPath(`contributor.${index}.awardNumber`);
+
+  // Get display values (pending change or original)
+  const displayName = nameChange ? (nameChange.newValue as string) : contributor.name;
+  const displayIdentifier = identifierChange ? (identifierChange.newValue as string) : contributor.identifier;
+  const displayRoles = rolesChange ? formatRoles(rolesChange.newValue as string[]) : formatRoles(contributor.roleName);
+  const displayIncludeInCitation = includeInCitationChange !== undefined 
+    ? (includeInCitationChange.newValue as boolean)
+    : contributor.includeInCitation;
+  const displayEmail = emailChange ? (emailChange.newValue as string) : contributor.email;
+  const displayUrl = urlChange ? (urlChange.newValue as string) : contributor.url;
+  const displayAwardNumber = awardNumberChange ? (awardNumberChange.newValue as string) : contributor.awardNumber;
+
+  const rowHighlight = hasChange || hasChildChanges;
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          backgroundColor: rowHighlight ? 'success.lighter' : 'transparent',
+          '&:hover': { backgroundColor: rowHighlight ? 'success.light' : 'action.hover' },
+        }}
+      >
+        <TableCell sx={{ py: 0.75, width: 40 }}>
+          {showExpand ? (
+            <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ p: 0.25 }}>
+              {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+          ) : (
+            <Box sx={{ width: 24 }} />
+          )}
+        </TableCell>
+        <TableCell sx={{ py: 0.75 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Tooltip title={isPerson ? 'Person' : 'Organization'}>
+              {isPerson ? (
+                <PersonIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+              ) : (
+                <BusinessIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+              )}
+            </Tooltip>
+            <Box>
+              {nameChange && (
+                <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.75rem' }}>
+                  {contributor.name}
+                </Typography>
+              )}
+              <Typography variant="body2" sx={{ fontWeight: 500, color: nameChange ? 'success.dark' : 'text.primary' }}>
+                {displayName}
+              </Typography>
+            </Box>
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75 }}>
+          <Box>
+            {identifierChange && contributor.identifier && (
+              <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', textDecoration: 'line-through', color: 'error.main' }}>
+                {contributor.identifier}
+              </Typography>
+            )}
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: identifierChange ? 'success.dark' : 'text.primary' }}>
+              {displayIdentifier || '—'}
+            </Typography>
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75 }}>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {displayRoles.length > 0 ? (
+              displayRoles.slice(0, 3).map((role: string, i: number) => (
+                <Chip key={i} label={role} size="small" variant="outlined" sx={{ height: 20, fontSize: '0.7rem', borderColor: rolesChange ? 'success.main' : undefined }} />
+              ))
+            ) : (
+              <Typography variant="body2" color="text.secondary">—</Typography>
+            )}
+            {displayRoles.length > 3 && (
+              <Chip label={`+${displayRoles.length - 3}`} size="small" sx={{ height: 20, fontSize: '0.7rem' }} />
+            )}
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75, textAlign: 'center' }}>
+          {displayIncludeInCitation !== undefined ? (
+            <Box>
+              {includeInCitationChange && (
+                <Typography variant="caption" sx={{ textDecoration: 'line-through', color: 'error.main', mr: 0.5 }}>
+                  {contributor.includeInCitation ? 'Yes' : 'No'}
+                </Typography>
+              )}
+              <Chip 
+                label={displayIncludeInCitation ? 'Yes' : 'No'} 
+                size="small" 
+                color={displayIncludeInCitation ? 'success' : 'default'}
+                sx={{ 
+                  height: 20, 
+                  fontSize: '0.7rem',
+                  border: includeInCitationChange ? '2px solid' : undefined,
+                  borderColor: includeInCitationChange ? 'success.main' : undefined,
+                }}
+              />
+            </Box>
+          ) : '—'}
+        </TableCell>
+        <TableCell sx={{ py: 0.75, width: 50 }}>
+          {(hasChange || hasChildChanges) && onRevert && (
+            <Tooltip title="Revert all changes to this contributor">
+              <IconButton size="small" onClick={onRevert} color="warning" sx={{ p: 0.25 }}>
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </TableCell>
+      </TableRow>
+      {showExpand && (
+        <TableRow>
+          <TableCell colSpan={6} sx={{ py: 0, borderBottom: expanded ? undefined : 'none' }}>
+            <Collapse in={expanded}>
+              <Box sx={{ py: 1, pl: 6, pr: 2 }}>
+                <Table size="small" sx={{ backgroundColor: 'grey.50' }}>
+                  <TableBody>
+                    {(contributor.email || emailChange) && (
+                      <TableRow sx={{ backgroundColor: emailChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: emailChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>Email</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {emailChange && contributor.email && (
+                            <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem' }}>
+                              {contributor.email}
+                            </Typography>
+                          )}
+                          <Typography variant="body2" sx={{ color: emailChange ? 'success.dark' : 'text.primary' }}>
+                            {displayEmail || '—'}
+                          </Typography>
+                        </TableCell>
+                        {emailChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`contributor.${index}.email`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                    {(contributor.url || urlChange) && (
+                      <TableRow sx={{ backgroundColor: urlChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: urlChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>URL</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {urlChange && contributor.url && (
+                            <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem' }}>
+                              {contributor.url}
+                            </Typography>
+                          )}
+                          {displayUrl ? (
+                            <Typography variant="body2" component="a" href={displayUrl} target="_blank" sx={{ color: urlChange ? 'success.dark' : 'primary.main' }}>
+                              {displayUrl}
+                            </Typography>
+                          ) : (
+                            <Typography variant="body2" color="text.secondary">—</Typography>
+                          )}
+                        </TableCell>
+                        {urlChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`contributor.${index}.url`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                    {(contributor.awardNumber || awardNumberChange) && (
+                      <TableRow sx={{ backgroundColor: awardNumberChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: awardNumberChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>Award</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {awardNumberChange && contributor.awardNumber && (
+                            <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem' }}>
+                              {contributor.awardNumber}
+                            </Typography>
+                          )}
+                          <Typography variant="body2" sx={{ color: awardNumberChange ? 'success.dark' : 'text.primary' }}>
+                            {displayAwardNumber || '—'}
+                          </Typography>
+                        </TableCell>
+                        {awardNumberChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`contributor.${index}.awardNumber`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                    {contributor.affiliation && contributor.affiliation.length > 0 && (
+                      <TableRow>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: 'text.secondary', border: 0, py: 0.5, verticalAlign: 'top' }}>Affiliation</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {contributor.affiliation.map((aff, i) => (
+                            <Typography key={i} variant="body2">
+                              {typeof aff === 'object' && aff !== null && 'name' in aff 
+                                ? (aff as { name: string }).name 
+                                : String(aff)}
+                            </Typography>
+                          ))}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </Box>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+export function ContributorsTable() {
+  const { versionInfo, pendingChanges, removePendingChange, getPendingChangeForPath } = useMetadataContext();
+
+  if (!versionInfo) return null;
+
+  const contributors = versionInfo.metadata.contributor || [];
+
+  if (contributors.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', py: 1 }}>
+        No contributors
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: 'grey.100' }}>
+            <TableCell sx={{ py: 0.75, width: 40 }} />
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>Name</TableCell>
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>Identifier</TableCell>
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>Roles</TableCell>
+            <TableCell sx={{ py: 0.75, fontWeight: 600, textAlign: 'center' }}>In Citation</TableCell>
+            <TableCell sx={{ py: 0.75, width: 50 }} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {contributors.map((contributor, index) => {
+            const hasDirectChange = !!getPendingChangeForPath(`contributor.${index}`);
+            const hasChildChanges = pendingChanges.some(c => 
+              c.path.startsWith(`contributor.${index}.`)
+            );
+
+            const handleRevert = () => {
+              // Remove direct change
+              removePendingChange(`contributor.${index}`);
+              // Remove all child changes
+              pendingChanges
+                .filter(c => c.path.startsWith(`contributor.${index}.`))
+                .forEach(c => removePendingChange(c.path));
+            };
+
+            return (
+              <ContributorRow
+                key={index}
+                contributor={contributor}
+                index={index}
+                hasChange={hasDirectChange}
+                hasChildChanges={hasChildChanges}
+                onRevert={(hasDirectChange || hasChildChanges) ? handleRevert : undefined}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/Metadata/GenericArrayTable.tsx
+++ b/src/components/Metadata/GenericArrayTable.tsx
@@ -1,0 +1,352 @@
+import { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  IconButton,
+  Tooltip,
+  Chip,
+  Box,
+  Collapse,
+} from '@mui/material';
+import UndoIcon from '@mui/icons-material/Undo';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { useMetadataContext } from '../../context/MetadataContext';
+
+interface GenericItem {
+  schemaKey?: string;
+  name?: string;
+  identifier?: string;
+  [key: string]: unknown;
+}
+
+interface GenericRowProps {
+  item: GenericItem;
+  index: number;
+  path: string;
+  columns: ColumnDef[];
+  hasChange: boolean;
+  hasChildChanges: boolean;
+  onRevert?: () => void;
+}
+
+interface ColumnDef {
+  key: string;
+  label: string;
+  render?: (value: unknown, item: GenericItem) => React.ReactNode;
+}
+
+function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omit<GenericRowProps, 'index' | 'path'>) {
+  const [expanded, setExpanded] = useState(false);
+  
+  // Get extra fields not shown in columns
+  const columnKeys = columns.map(c => c.key);
+  const extraFields = Object.entries(item).filter(
+    ([key, value]) => 
+      !columnKeys.includes(key) && 
+      key !== 'schemaKey' && 
+      key !== 'id' &&
+      value !== null && 
+      value !== undefined &&
+      value !== ''
+  );
+  
+  const showExpand = extraFields.length > 0;
+  const rowHighlight = hasChange || hasChildChanges;
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          backgroundColor: rowHighlight ? 'success.lighter' : 'transparent',
+          '&:hover': { backgroundColor: rowHighlight ? 'success.light' : 'action.hover' },
+        }}
+      >
+        <TableCell sx={{ py: 0.75, width: 40 }}>
+          {showExpand ? (
+            <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ p: 0.25 }}>
+              {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+          ) : (
+            <Box sx={{ width: 24 }} />
+          )}
+        </TableCell>
+        {columns.map((col) => (
+          <TableCell key={col.key} sx={{ py: 0.75 }}>
+            {col.render 
+              ? col.render(item[col.key], item)
+              : formatValue(item[col.key])
+            }
+          </TableCell>
+        ))}
+        <TableCell sx={{ py: 0.75, width: 50 }}>
+          {(hasChange || hasChildChanges) && onRevert && (
+            <Tooltip title="Revert changes">
+              <IconButton size="small" onClick={onRevert} color="warning" sx={{ p: 0.25 }}>
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </TableCell>
+      </TableRow>
+      {showExpand && (
+        <TableRow>
+          <TableCell colSpan={columns.length + 2} sx={{ py: 0, borderBottom: expanded ? undefined : 'none' }}>
+            <Collapse in={expanded}>
+              <Box sx={{ py: 1, pl: 6, pr: 2 }}>
+                <Table size="small" sx={{ backgroundColor: 'grey.50' }}>
+                  <TableBody>
+                    {extraFields.map(([key, value]) => (
+                      <TableRow key={key}>
+                        <TableCell sx={{ width: 120, fontWeight: 500, color: 'text.secondary', border: 0, py: 0.5 }}>
+                          {formatLabel(key)}
+                        </TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {renderExpandedValue(value)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Box>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+function formatValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) return <Typography variant="body2" color="text.secondary">—</Typography>;
+  if (typeof value === 'string') return <Typography variant="body2">{value || '—'}</Typography>;
+  if (typeof value === 'boolean') return <Chip label={value ? 'Yes' : 'No'} size="small" sx={{ height: 20, fontSize: '0.7rem' }} />;
+  if (typeof value === 'number') return <Typography variant="body2">{value}</Typography>;
+  if (Array.isArray(value)) return <Typography variant="body2" color="text.secondary">[{value.length} items]</Typography>;
+  if (typeof value === 'object') return <Typography variant="body2" color="text.secondary">{'{...}'}</Typography>;
+  return <Typography variant="body2">{String(value)}</Typography>;
+}
+
+function renderExpandedValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return String(value);
+  if (Array.isArray(value)) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        {value.map((item, i) => (
+          <Typography key={i} variant="body2">
+            {typeof item === 'object' && item !== null
+              ? ('name' in item ? (item as { name: string }).name : JSON.stringify(item))
+              : String(item)}
+          </Typography>
+        ))}
+      </Box>
+    );
+  }
+  if (typeof value === 'object') {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+        {Object.entries(value as Record<string, unknown>)
+          .filter(([k, v]) => k !== 'schemaKey' && k !== 'id' && v !== null && v !== undefined)
+          .map(([k, v]) => (
+            <Typography key={k} variant="body2">
+              <strong>{formatLabel(k)}:</strong> {typeof v === 'string' ? v : JSON.stringify(v)}
+            </Typography>
+          ))
+        }
+      </Box>
+    );
+  }
+  return String(value);
+}
+
+function formatLabel(key: string): string {
+  // Convert camelCase to Title Case
+  return key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, str => str.toUpperCase())
+    .trim();
+}
+
+interface GenericArrayTableProps {
+  path: string;
+  items: GenericItem[] | undefined | null;
+  columns: ColumnDef[];
+  emptyMessage?: string;
+}
+
+export function GenericArrayTable({ path, items, columns, emptyMessage = 'No items' }: GenericArrayTableProps) {
+  const { pendingChanges, removePendingChange, getPendingChangeForPath } = useMetadataContext();
+
+  const displayItems = items || [];
+
+  if (displayItems.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', py: 1 }}>
+        {emptyMessage}
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: 'grey.100' }}>
+            <TableCell sx={{ py: 0.75, width: 40 }} />
+            {columns.map((col) => (
+              <TableCell key={col.key} sx={{ py: 0.75, fontWeight: 600 }}>
+                {col.label}
+              </TableCell>
+            ))}
+            <TableCell sx={{ py: 0.75, width: 50 }} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {displayItems.map((item, index) => {
+            const itemPath = `${path}.${index}`;
+            const hasDirectChange = !!getPendingChangeForPath(itemPath);
+            const hasChildChanges = pendingChanges.some(c => 
+              c.path.startsWith(`${itemPath}.`)
+            );
+
+            const handleRevert = () => {
+              removePendingChange(itemPath);
+              pendingChanges
+                .filter(c => c.path.startsWith(`${itemPath}.`))
+                .forEach(c => removePendingChange(c.path));
+            };
+
+            return (
+              <GenericRow
+                key={index}
+                item={item}
+                columns={columns}
+                hasChange={hasDirectChange}
+                hasChildChanges={hasChildChanges}
+                onRevert={(hasDirectChange || hasChildChanges) ? handleRevert : undefined}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+// Pre-configured tables for specific types
+
+export function AboutTable() {
+  const { versionInfo } = useMetadataContext();
+  if (!versionInfo) return null;
+
+  const columns: ColumnDef[] = [
+    { 
+      key: 'name', 
+      label: 'Name',
+      render: (value) => (
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {(value as string) || '—'}
+        </Typography>
+      )
+    },
+    { 
+      key: 'identifier', 
+      label: 'Identifier',
+      render: (value) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+          {(value as string) || '—'}
+        </Typography>
+      )
+    },
+    { 
+      key: 'schemaKey', 
+      label: 'Type',
+      render: (value) => (
+        <Chip 
+          label={(value as string)?.replace('Type', '') || 'Unknown'} 
+          size="small" 
+          variant="outlined"
+          sx={{ height: 20, fontSize: '0.7rem' }} 
+        />
+      )
+    },
+  ];
+
+  return (
+    <GenericArrayTable
+      path="about"
+      items={versionInfo.metadata.about as GenericItem[]}
+      columns={columns}
+      emptyMessage="No subject matter specified"
+    />
+  );
+}
+
+export function EthicsApprovalTable() {
+  const { versionInfo } = useMetadataContext();
+  if (!versionInfo) return null;
+
+  const columns: ColumnDef[] = [
+    { 
+      key: 'identifier', 
+      label: 'Protocol Identifier',
+      render: (value) => (
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {(value as string) || '—'}
+        </Typography>
+      )
+    },
+  ];
+
+  return (
+    <GenericArrayTable
+      path="ethicsApproval"
+      items={versionInfo.metadata.ethicsApproval as GenericItem[]}
+      columns={columns}
+      emptyMessage="No ethics approvals"
+    />
+  );
+}
+
+export function ProjectsTable() {
+  const { versionInfo } = useMetadataContext();
+  if (!versionInfo) return null;
+
+  const columns: ColumnDef[] = [
+    { 
+      key: 'name', 
+      label: 'Name',
+      render: (value) => (
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {(value as string) || '—'}
+        </Typography>
+      )
+    },
+    { 
+      key: 'identifier', 
+      label: 'Identifier',
+      render: (value) => (
+        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+          {(value as string) || '—'}
+        </Typography>
+      )
+    },
+  ];
+
+  return (
+    <GenericArrayTable
+      path="wasGeneratedBy"
+      items={versionInfo.metadata.wasGeneratedBy as GenericItem[]}
+      columns={columns}
+      emptyMessage="No associated projects"
+    />
+  );
+}

--- a/src/components/Metadata/MetadataDisplay.tsx
+++ b/src/components/Metadata/MetadataDisplay.tsx
@@ -1,31 +1,37 @@
 import { Box, Typography, Paper, Divider } from '@mui/material';
 import { useMetadataContext } from '../../context/MetadataContext';
-import { MetadataField } from './MetadataField';
-import type { DandisetMetadata } from '../../types/dandiset';
+import { SimpleFieldsTable } from './SimpleFieldsTable';
+import { ContributorsTable } from './ContributorsTable';
+import { RelatedResourcesTable } from './RelatedResourcesTable';
+import { StringArrayField } from './StringArrayField';
+import { AboutTable, EthicsApprovalTable, ProjectsTable } from './GenericArrayTable';
+import { ReadOnlySection } from './ReadOnlySection';
 
-// Define which fields to display and in what order
-const DISPLAY_FIELDS: (keyof DandisetMetadata)[] = [
-  'name',
-  'description',
-  'identifier',
-  'url',
-  'license',
-  'citation',
-  'contributor',
-  'access',
-  'about',
-  'keywords',
-  'relatedResource',
-  'ethicsApproval',
-  'wasGeneratedBy',
-  'studyTarget',
-  'protocol',
-  'assetsSummary',
-  'schemaVersion',
-  'repository',
-  'manifestLocation',
-  'dateCreated',
-];
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography 
+        variant="subtitle2" 
+        sx={{ 
+          fontWeight: 600, 
+          color: 'text.secondary', 
+          mb: 1,
+          textTransform: 'uppercase',
+          fontSize: '0.7rem',
+          letterSpacing: '0.5px',
+        }}
+      >
+        {title}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
 
 export function MetadataDisplay() {
   const { versionInfo } = useMetadataContext();
@@ -56,23 +62,69 @@ export function MetadataDisplay() {
       </Typography>
       <Divider sx={{ mb: 2 }} />
 
-      <Box>
-        {DISPLAY_FIELDS.map((field) => {
-          const value = metadata[field];
-          // Skip undefined fields
-          if (value === undefined) return null;
+      {/* Basic Information */}
+      <Section title="Basic Information">
+        <SimpleFieldsTable />
+      </Section>
 
-          return (
-            <MetadataField
-              key={field}
-              label={field}
-              path={field}
-              value={value}
-              depth={0}
-            />
-          );
-        })}
-      </Box>
+      {/* License */}
+      <Section title="License">
+        <StringArrayField 
+          label="License" 
+          path="license" 
+          values={metadata.license?.map(l => l.replace('spdx:', ''))} 
+        />
+      </Section>
+
+      {/* Keywords & Study Targets */}
+      <Section title="Keywords & Study">
+        <StringArrayField 
+          label="Keywords" 
+          path="keywords" 
+          values={metadata.keywords} 
+        />
+        <StringArrayField 
+          label="Study Target" 
+          path="studyTarget" 
+          values={metadata.studyTarget as string[] | undefined} 
+        />
+        <StringArrayField 
+          label="Protocol" 
+          path="protocol" 
+          values={metadata.protocol}
+          isUrl
+        />
+      </Section>
+
+      {/* Subject Matter (About) */}
+      <Section title="Subject Matter">
+        <AboutTable />
+      </Section>
+
+      {/* Contributors */}
+      <Section title="Contributors">
+        <ContributorsTable />
+      </Section>
+
+      {/* Related Resources */}
+      <Section title="Related Resources">
+        <RelatedResourcesTable />
+      </Section>
+
+      {/* Ethics Approval */}
+      <Section title="Ethics Approvals">
+        <EthicsApprovalTable />
+      </Section>
+
+      {/* Projects */}
+      <Section title="Associated Projects">
+        <ProjectsTable />
+      </Section>
+
+      <Divider sx={{ my: 2 }} />
+
+      {/* Read-only Fields */}
+      <ReadOnlySection />
     </Paper>
   );
 }

--- a/src/components/Metadata/ReadOnlySection.tsx
+++ b/src/components/Metadata/ReadOnlySection.tsx
@@ -1,0 +1,264 @@
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Collapse,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Link,
+  Chip,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import LockIcon from '@mui/icons-material/Lock';
+import { useMetadataContext } from '../../context/MetadataContext';
+
+function formatDate(dateString: string | null | undefined): string {
+  if (!dateString) return '—';
+  try {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return dateString;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+interface ReadOnlyFieldProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+function ReadOnlyField({ label, value }: ReadOnlyFieldProps) {
+  return (
+    <TableRow>
+      <TableCell 
+        sx={{ 
+          width: 140, 
+          fontWeight: 500, 
+          color: 'text.secondary',
+          py: 0.5,
+          border: 0,
+          verticalAlign: 'top',
+        }}
+      >
+        {label}
+      </TableCell>
+      <TableCell sx={{ py: 0.5, border: 0 }}>
+        {value}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function ReadOnlySection() {
+  const [expanded, setExpanded] = useState(false);
+  const { versionInfo } = useMetadataContext();
+
+  if (!versionInfo) return null;
+
+  const metadata = versionInfo.metadata;
+
+  return (
+    <Box 
+      sx={{ 
+        backgroundColor: 'grey.50', 
+        borderRadius: 1, 
+        border: '1px solid',
+        borderColor: 'grey.200',
+      }}
+    >
+      {/* Header */}
+      <Box 
+        sx={{ 
+          display: 'flex', 
+          alignItems: 'center', 
+          justifyContent: 'space-between',
+          px: 2,
+          py: 1,
+          cursor: 'pointer',
+          '&:hover': { backgroundColor: 'grey.100' },
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <LockIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+          <Typography variant="body2" color="text.secondary" fontWeight={500}>
+            Read-only Fields
+          </Typography>
+          <Chip 
+            label="Auto-generated" 
+            size="small" 
+            sx={{ height: 18, fontSize: '0.65rem', backgroundColor: 'grey.200' }} 
+          />
+        </Box>
+        <IconButton size="small" sx={{ p: 0.25 }}>
+          {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+        </IconButton>
+      </Box>
+
+      {/* Content */}
+      <Collapse in={expanded}>
+        <Box sx={{ px: 2, pb: 2 }}>
+          <Table size="small">
+            <TableBody>
+              <ReadOnlyField 
+                label="ID" 
+                value={
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                    {metadata.id}
+                  </Typography>
+                }
+              />
+              <ReadOnlyField 
+                label="Identifier" 
+                value={
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                    {metadata.identifier}
+                  </Typography>
+                }
+              />
+              <ReadOnlyField 
+                label="URL" 
+                value={
+                  metadata.url ? (
+                    <Link href={metadata.url} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.85rem' }}>
+                      {metadata.url}
+                    </Link>
+                  ) : '—'
+                }
+              />
+              <ReadOnlyField 
+                label="Repository" 
+                value={
+                  metadata.repository ? (
+                    <Link href={metadata.repository} target="_blank" rel="noopener noreferrer" sx={{ fontSize: '0.85rem' }}>
+                      {metadata.repository}
+                    </Link>
+                  ) : '—'
+                }
+              />
+              <ReadOnlyField 
+                label="Version" 
+                value={<Typography variant="body2">{metadata.version}</Typography>}
+              />
+              <ReadOnlyField 
+                label="Schema Version" 
+                value={<Typography variant="body2">{metadata.schemaVersion}</Typography>}
+              />
+              <ReadOnlyField 
+                label="Date Created" 
+                value={<Typography variant="body2">{formatDate(metadata.dateCreated)}</Typography>}
+              />
+              <ReadOnlyField 
+                label="Citation" 
+                value={
+                  <Typography variant="body2" sx={{ fontSize: '0.8rem', fontStyle: 'italic' }}>
+                    {metadata.citation || '—'}
+                  </Typography>
+                }
+              />
+              
+              {/* Access */}
+              {metadata.access && metadata.access.length > 0 && (
+                <ReadOnlyField 
+                  label="Access" 
+                  value={
+                    <Box sx={{ display: 'flex', gap: 0.5 }}>
+                      {metadata.access.map((a, i) => (
+                        <Chip 
+                          key={i} 
+                          label={a.status.replace('dandi:', '')} 
+                          size="small"
+                          color={a.status === 'dandi:OpenAccess' ? 'success' : 'warning'}
+                          sx={{ height: 20, fontSize: '0.7rem' }}
+                        />
+                      ))}
+                    </Box>
+                  }
+                />
+              )}
+
+              {/* Assets Summary */}
+              {metadata.assetsSummary && (
+                <>
+                  <ReadOnlyField 
+                    label="Files" 
+                    value={
+                      <Typography variant="body2">
+                        {metadata.assetsSummary.numberOfFiles?.toLocaleString() || 0} files
+                      </Typography>
+                    }
+                  />
+                  <ReadOnlyField 
+                    label="Size" 
+                    value={
+                      <Typography variant="body2">
+                        {formatBytes(metadata.assetsSummary.numberOfBytes || 0)}
+                      </Typography>
+                    }
+                  />
+                  {metadata.assetsSummary.species && metadata.assetsSummary.species.length > 0 && (
+                    <ReadOnlyField 
+                      label="Species" 
+                      value={
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {metadata.assetsSummary.species.map((s, i) => (
+                            <Chip 
+                              key={i} 
+                              label={typeof s === 'object' && s !== null && 'name' in s ? (s as { name: string }).name : String(s)} 
+                              size="small"
+                              variant="outlined"
+                              sx={{ height: 20, fontSize: '0.7rem' }}
+                            />
+                          ))}
+                        </Box>
+                      }
+                    />
+                  )}
+                </>
+              )}
+
+              {/* Manifest Location */}
+              {metadata.manifestLocation && metadata.manifestLocation.length > 0 && (
+                <ReadOnlyField 
+                  label="Manifest" 
+                  value={
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                      {metadata.manifestLocation.map((url, i) => (
+                        <Link 
+                          key={i} 
+                          href={url} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          sx={{ fontSize: '0.8rem' }}
+                        >
+                          {url.length > 60 ? url.slice(0, 60) + '...' : url}
+                        </Link>
+                      ))}
+                    </Box>
+                  }
+                />
+              )}
+            </TableBody>
+          </Table>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/src/components/Metadata/RelatedResourcesTable.tsx
+++ b/src/components/Metadata/RelatedResourcesTable.tsx
@@ -1,0 +1,300 @@
+import { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  IconButton,
+  Tooltip,
+  Chip,
+  Box,
+  Collapse,
+  Link,
+} from '@mui/material';
+import UndoIcon from '@mui/icons-material/Undo';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import LinkIcon from '@mui/icons-material/Link';
+import { useMetadataContext } from '../../context/MetadataContext';
+import type { RelatedResource } from '../../types/dandiset';
+
+interface ResourceRowProps {
+  resource: RelatedResource;
+  index: number;
+  hasChange: boolean;
+  hasChildChanges: boolean;
+  onRevert?: () => void;
+}
+
+function formatRelation(relation: string): string {
+  return relation.replace('dcite:', '');
+}
+
+function formatResourceType(type?: string): string {
+  if (!type) return '';
+  return type.replace('dcite:', '');
+}
+
+function ResourceRow({ resource, index, hasChange, hasChildChanges, onRevert }: ResourceRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { removePendingChange, getPendingChangeForPath } = useMetadataContext();
+
+  // Get pending changes for specific fields
+  const nameChange = getPendingChangeForPath(`relatedResource.${index}.name`);
+  const urlChange = getPendingChangeForPath(`relatedResource.${index}.url`);
+  const relationChange = getPendingChangeForPath(`relatedResource.${index}.relation`);
+  const identifierChange = getPendingChangeForPath(`relatedResource.${index}.identifier`);
+  const repositoryChange = getPendingChangeForPath(`relatedResource.${index}.repository`);
+  const resourceTypeChange = getPendingChangeForPath(`relatedResource.${index}.resourceType`);
+
+  // Get display values (pending change or original)
+  const displayName = nameChange ? (nameChange.newValue as string) : resource.name;
+  const displayUrl = urlChange ? (urlChange.newValue as string) : resource.url;
+  const displayRelation = relationChange ? (relationChange.newValue as string) : resource.relation;
+  const displayIdentifier = identifierChange ? (identifierChange.newValue as string) : resource.identifier;
+  const displayRepository = repositoryChange ? (repositoryChange.newValue as string) : resource.repository;
+  const displayResourceType = resourceTypeChange ? (resourceTypeChange.newValue as string) : resource.resourceType;
+
+  const showExpand = displayIdentifier || displayRepository || displayResourceType;
+
+  const rowHighlight = hasChange || hasChildChanges;
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          backgroundColor: rowHighlight ? 'success.lighter' : 'transparent',
+          '&:hover': { backgroundColor: rowHighlight ? 'success.light' : 'action.hover' },
+        }}
+      >
+        <TableCell sx={{ py: 0.75, width: 40 }}>
+          {showExpand ? (
+            <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ p: 0.25 }}>
+              {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+          ) : (
+            <Box sx={{ width: 24 }} />
+          )}
+        </TableCell>
+        <TableCell sx={{ py: 0.75 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <LinkIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+            <Box>
+              {nameChange && resource.name && (
+                <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.75rem' }}>
+                  {resource.name}
+                </Typography>
+              )}
+              <Typography variant="body2" sx={{ fontWeight: 500, color: nameChange ? 'success.dark' : 'text.primary' }}>
+                {displayName || '(unnamed)'}
+              </Typography>
+            </Box>
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75, maxWidth: 200 }}>
+          <Box>
+            {urlChange && resource.url && (
+              <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.7rem' }}>
+                {resource.url}
+              </Typography>
+            )}
+            {displayUrl ? (
+              <Link 
+                href={displayUrl} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                sx={{ 
+                  fontSize: '0.8rem', 
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  color: urlChange ? 'success.dark' : 'primary.main',
+                }}
+              >
+                {displayUrl}
+              </Link>
+            ) : (
+              <Typography variant="body2" color="text.secondary">—</Typography>
+            )}
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75 }}>
+          <Box>
+            {relationChange && (
+              <Typography variant="caption" sx={{ textDecoration: 'line-through', color: 'error.main', mr: 0.5 }}>
+                {formatRelation(resource.relation)}
+              </Typography>
+            )}
+            <Chip 
+              label={formatRelation(displayRelation)} 
+              size="small" 
+              variant="outlined"
+              sx={{ 
+                height: 20, 
+                fontSize: '0.7rem',
+                borderColor: relationChange ? 'success.main' : undefined,
+              }} 
+            />
+          </Box>
+        </TableCell>
+        <TableCell sx={{ py: 0.75, width: 50 }}>
+          {(hasChange || hasChildChanges) && onRevert && (
+            <Tooltip title="Revert all changes to this resource">
+              <IconButton size="small" onClick={onRevert} color="warning" sx={{ p: 0.25 }}>
+                <UndoIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </TableCell>
+      </TableRow>
+      {showExpand && (
+        <TableRow>
+          <TableCell colSpan={5} sx={{ py: 0, borderBottom: expanded ? undefined : 'none' }}>
+            <Collapse in={expanded}>
+              <Box sx={{ py: 1, pl: 6, pr: 2 }}>
+                <Table size="small" sx={{ backgroundColor: 'grey.50' }}>
+                  <TableBody>
+                    {(resource.identifier || identifierChange) && (
+                      <TableRow sx={{ backgroundColor: identifierChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: identifierChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>Identifier</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {identifierChange && resource.identifier && (
+                            <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem' }}>
+                              {resource.identifier}
+                            </Typography>
+                          )}
+                          <Typography variant="body2" sx={{ color: identifierChange ? 'success.dark' : 'text.primary' }}>
+                            {displayIdentifier || '—'}
+                          </Typography>
+                        </TableCell>
+                        {identifierChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`relatedResource.${index}.identifier`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                    {(resource.repository || repositoryChange) && (
+                      <TableRow sx={{ backgroundColor: repositoryChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: repositoryChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>Repository</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {repositoryChange && resource.repository && (
+                            <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem' }}>
+                              {resource.repository}
+                            </Typography>
+                          )}
+                          <Typography variant="body2" sx={{ color: repositoryChange ? 'success.dark' : 'text.primary' }}>
+                            {displayRepository || '—'}
+                          </Typography>
+                        </TableCell>
+                        {repositoryChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`relatedResource.${index}.repository`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                    {(resource.resourceType || resourceTypeChange) && (
+                      <TableRow sx={{ backgroundColor: resourceTypeChange ? 'success.lighter' : 'transparent' }}>
+                        <TableCell sx={{ width: 100, fontWeight: 500, color: resourceTypeChange ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>Type</TableCell>
+                        <TableCell sx={{ border: 0, py: 0.5 }}>
+                          {resourceTypeChange && resource.resourceType && (
+                            <Typography variant="caption" sx={{ textDecoration: 'line-through', color: 'error.main', mr: 0.5 }}>
+                              {formatResourceType(resource.resourceType)}
+                            </Typography>
+                          )}
+                          <Chip 
+                            label={formatResourceType(displayResourceType)} 
+                            size="small" 
+                            sx={{ 
+                              height: 20, 
+                              fontSize: '0.7rem',
+                              borderColor: resourceTypeChange ? 'success.main' : undefined,
+                            }} 
+                          />
+                        </TableCell>
+                        {resourceTypeChange && (
+                          <TableCell sx={{ border: 0, py: 0.5, width: 40 }}>
+                            <IconButton size="small" onClick={() => removePendingChange(`relatedResource.${index}.resourceType`)} color="warning">
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </Box>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+export function RelatedResourcesTable() {
+  const { versionInfo, pendingChanges, removePendingChange, getPendingChangeForPath } = useMetadataContext();
+
+  if (!versionInfo) return null;
+
+  const resources = versionInfo.metadata.relatedResource || [];
+
+  if (resources.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', py: 1 }}>
+        No related resources
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: 'grey.100' }}>
+            <TableCell sx={{ py: 0.75, width: 40 }} />
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>Name</TableCell>
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>URL</TableCell>
+            <TableCell sx={{ py: 0.75, fontWeight: 600 }}>Relation</TableCell>
+            <TableCell sx={{ py: 0.75, width: 50 }} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {resources.map((resource, index) => {
+            const hasDirectChange = !!getPendingChangeForPath(`relatedResource.${index}`);
+            const hasChildChanges = pendingChanges.some(c => 
+              c.path.startsWith(`relatedResource.${index}.`)
+            );
+
+            const handleRevert = () => {
+              removePendingChange(`relatedResource.${index}`);
+              pendingChanges
+                .filter(c => c.path.startsWith(`relatedResource.${index}.`))
+                .forEach(c => removePendingChange(c.path));
+            };
+
+            return (
+              <ResourceRow
+                key={index}
+                resource={resource}
+                index={index}
+                hasChange={hasDirectChange}
+                hasChildChanges={hasChildChanges}
+                onRevert={(hasDirectChange || hasChildChanges) ? handleRevert : undefined}
+              />
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/Metadata/SimpleFieldsTable.tsx
+++ b/src/components/Metadata/SimpleFieldsTable.tsx
@@ -1,0 +1,115 @@
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableContainer, 
+  TableRow, 
+  Typography, 
+  IconButton, 
+  Tooltip,
+  Box 
+} from '@mui/material';
+import UndoIcon from '@mui/icons-material/Undo';
+import { useMetadataContext } from '../../context/MetadataContext';
+
+// Field definitions with display labels
+const SIMPLE_FIELDS = [
+  { key: 'name', label: 'Title', description: 'A title associated with the Dandiset' },
+  { key: 'description', label: 'Description', description: 'A description of the Dandiset' },
+  { key: 'acknowledgement', label: 'Acknowledgement', description: 'Any acknowledgments not covered by contributors or external resources' },
+] as const;
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value || '—';
+  return String(value);
+}
+
+export function SimpleFieldsTable() {
+  const { versionInfo, getPendingChangeForPath, removePendingChange } = useMetadataContext();
+
+  if (!versionInfo) return null;
+
+  const metadata = versionInfo.metadata;
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableBody>
+          {SIMPLE_FIELDS.map(({ key, label }) => {
+            const value = metadata[key as keyof typeof metadata];
+            const pendingChange = getPendingChangeForPath(key);
+            const hasChange = !!pendingChange;
+            const displayValue = hasChange ? pendingChange.newValue : value;
+
+            return (
+              <TableRow 
+                key={key}
+                sx={{ 
+                  '&:last-child td, &:last-child th': { border: 0 },
+                  backgroundColor: hasChange ? 'success.lighter' : 'transparent',
+                }}
+              >
+                <TableCell 
+                  component="th" 
+                  scope="row"
+                  sx={{ 
+                    width: 140,
+                    fontWeight: 500,
+                    color: hasChange ? 'primary.main' : 'text.secondary',
+                    verticalAlign: 'top',
+                    py: 1,
+                  }}
+                >
+                  {label}
+                </TableCell>
+                <TableCell sx={{ py: 1 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      {hasChange && pendingChange.oldValue !== undefined && (
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: 'error.main',
+                            textDecoration: 'line-through',
+                            fontSize: '0.8rem',
+                            mb: 0.5,
+                            wordBreak: 'break-word',
+                          }}
+                        >
+                          {formatValue(pendingChange.oldValue)}
+                        </Typography>
+                      )}
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          wordBreak: 'break-word',
+                          whiteSpace: 'pre-wrap',
+                          color: hasChange ? 'success.dark' : 'text.primary',
+                        }}
+                      >
+                        {formatValue(displayValue)}
+                      </Typography>
+                    </Box>
+                    {hasChange && (
+                      <Tooltip title="Revert change">
+                        <IconButton 
+                          size="small" 
+                          onClick={() => removePendingChange(key)}
+                          color="warning"
+                          sx={{ flexShrink: 0 }}
+                        >
+                          <UndoIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </Box>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/components/Metadata/StringArrayField.tsx
+++ b/src/components/Metadata/StringArrayField.tsx
@@ -1,0 +1,112 @@
+import {
+  Box,
+  Chip,
+  Typography,
+  IconButton,
+  Tooltip,
+  Link,
+} from '@mui/material';
+import UndoIcon from '@mui/icons-material/Undo';
+import { useMetadataContext } from '../../context/MetadataContext';
+
+interface StringArrayFieldProps {
+  label: string;
+  path: string;
+  values: string[] | undefined | null;
+  isUrl?: boolean;
+}
+
+export function StringArrayField({ label, path, values, isUrl = false }: StringArrayFieldProps) {
+  const { getPendingChangeForPath, removePendingChange, pendingChanges } = useMetadataContext();
+  
+  const pendingChange = getPendingChangeForPath(path);
+  const hasChange = !!pendingChange;
+  
+  // Check for item-level changes (e.g., keywords.0)
+  const itemChanges = pendingChanges.filter(c => 
+    c.path.startsWith(`${path}.`) && !c.path.slice(path.length + 1).includes('.')
+  );
+  const hasItemChanges = itemChanges.length > 0;
+  
+  const displayValues = hasChange 
+    ? (pendingChange.newValue as string[] | null) || []
+    : values || [];
+
+  const handleRevert = () => {
+    removePendingChange(path);
+    itemChanges.forEach(c => removePendingChange(c.path));
+  };
+
+  const isEmpty = displayValues.length === 0 && !hasChange && !hasItemChanges;
+
+  return (
+    <Box 
+      sx={{ 
+        display: 'flex', 
+        alignItems: 'flex-start', 
+        py: 0.75,
+        backgroundColor: (hasChange || hasItemChanges) ? 'success.lighter' : 'transparent',
+        px: 1,
+        borderRadius: 1,
+        mb: 0.5,
+      }}
+    >
+      <Typography 
+        variant="body2" 
+        sx={{ 
+          fontWeight: 500, 
+          color: (hasChange || hasItemChanges) ? 'primary.main' : 'text.secondary',
+          minWidth: 120,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </Typography>
+      <Box sx={{ flex: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+        {isEmpty ? (
+          <Typography variant="body2" color="text.secondary">—</Typography>
+        ) : isUrl ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+            {displayValues.map((value, i) => (
+              <Link 
+                key={i} 
+                href={value} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                sx={{ fontSize: '0.85rem' }}
+              >
+                {value}
+              </Link>
+            ))}
+          </Box>
+        ) : (
+          displayValues.map((value, i) => (
+            <Chip
+              key={i}
+              label={value}
+              size="small"
+              variant="outlined"
+              sx={{ 
+                height: 22, 
+                fontSize: '0.75rem',
+                backgroundColor: itemChanges.some(c => c.path === `${path}.${i}`) ? 'success.light' : undefined,
+              }}
+            />
+          ))
+        )}
+      </Box>
+      {(hasChange || hasItemChanges) && (
+        <Tooltip title="Revert changes">
+          <IconButton 
+            size="small" 
+            onClick={handleRevert}
+            color="warning"
+            sx={{ flexShrink: 0, ml: 1 }}
+          >
+            <UndoIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
@bendichter you can preview these changes here:
https://dandiset-metadata-assistant.surge.sh/dandiset-metadata-assistant/

If it looks good to you, it's ready to merge.

### Summary

Refactored the metadata display panel to use a more compact, tabular layout while preserving all existing functionality for viewing and managing pending changes.

### Changes

__New Components:__

- `SimpleFieldsTable.tsx` - Two-column table for basic scalar fields (Title, Description, Acknowledgement)
- `ContributorsTable.tsx` - Table view for contributors with Name, Identifier, Roles, In Citation columns and expandable detail rows
- `RelatedResourcesTable.tsx` - Table view for related resources with Name, URL, Relation columns
- `StringArrayField.tsx` - Compact chip-based display for string arrays (keywords, protocols, studyTarget)
- `GenericArrayTable.tsx` - Reusable table component for object arrays (About, Ethics Approvals, Projects)
- `ReadOnlySection.tsx` - Collapsible section for read-only/auto-generated fields

__Updated:__

- `MetadataDisplay.tsx` - Reorganized to use new table components with logical section groupings

### Features

- __True tabular layout__: Data organized into tables with headers and aligned columns

- __Compact design__: Reduced vertical spacing while maintaining readability

- __Preserved functionality__:

  - Pending changes shown with strikethrough (old) → highlighted (new) values
  - Individual revert buttons for each change
  - Expand/collapse for nested object details

- __Read-only field separation__: Auto-generated fields (ID, URL, Citation, etc.) collapsed by default to reduce visual clutter

- __Section organization__: Fields grouped into logical sections (Basic Information, License, Keywords & Study, Contributors, etc.)
