### PR TITLE
Include embargoed dandisets in 'my dandisets' view

### DIFF
--- a/src/components/Welcome/WelcomePage.tsx
+++ b/src/components/Welcome/WelcomePage.tsx
@@ -22,6 +22,7 @@ import KeyIcon from '@mui/icons-material/Key';
 import SortIcon from '@mui/icons-material/Sort';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import LockIcon from '@mui/icons-material/Lock';
 import { useMetadataContext } from '../../context/MetadataContext';
 import {
   fetchDandisetVersionInfo,
@@ -346,6 +347,23 @@ export function WelcomePage({ onDandisetLoaded }: WelcomePageProps) {
                       >
                         {dandiset.draft_version.status}
                       </Typography>
+                      {dandiset.embargo_status === 'EMBARGOED' && (
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.5,
+                            px: 1,
+                            py: 0.25,
+                            borderRadius: 1,
+                            backgroundColor: 'warning.light',
+                            color: 'white',
+                          }}
+                        >
+                          <LockIcon sx={{ fontSize: 14 }} />
+                          <Typography variant="caption">Embargoed</Typography>
+                        </Box>
+                      )}
                     </Box>
                   }
                   secondary={

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,6 +6,7 @@ export interface OwnedDandiset {
   identifier: string;
   created: string;
   modified: string;
+  embargo_status: string;
   draft_version: {
     version: string;
     name: string;
@@ -19,7 +20,7 @@ export async function fetchOwnedDandisets(
   apiKey: string,
   order: DandisetSortOrder = '-modified'
 ): Promise<OwnedDandiset[]> {
-  const url = `${DANDI_API_BASE}/dandisets/?user=me&order=${order}&page_size=100`;
+  const url = `${DANDI_API_BASE}/dandisets/?user=me&order=${order}&page_size=100&embargoed=true`;
 
   const response = await fetch(url, {
     headers: {


### PR DESCRIPTION
This PR fixes the issue where only non-embargoed dandisets were shown in the 'my dandisets' view.

## Changes:
- Updated API call to include  parameter in 
- Added  field to the  type
- Added visual indicator (lock icon + badge) in the UI to clearly identify embargoed dandisets

Now users can see and access all their dandisets, including embargoed ones, with a clear visual distinction between embargoed and non-embargoed datasets.