### PR TITLE
Add build:surge script for Surge deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+dist-surge
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:surge": "npm run build && mkdir -p dist-surge/dandiset-metadata-assistant && cp -r dist/* dist-surge/dandiset-metadata-assistant/",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
Adds a build:surge npm script that creates the correct subdirectory structure for Surge deployment.

The script:
- Runs the standard build to create dist/
- Creates dist-surge/dandiset-metadata-assistant/
- Copies all built files to the subdirectory

This allows deploying to Surge with:
```
npm run build:surge
surge dist-surge dandiset-metadata-assistant.surge.sh
```

GitHub Actions deployment remains unaffected and continues to use `npm run build`.