### PR TITLE
Fix double scrollbar issue on welcome page

### DIFF
--- a/src/components/Welcome/WelcomePage.tsx
+++ b/src/components/Welcome/WelcomePage.tsx
@@ -238,6 +238,9 @@ export function WelcomePage({ onDandisetLoaded }: WelcomePageProps) {
           p: 4,
           maxWidth: 600,
           width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          maxHeight: '100%',
         }}
       >
         {/* Header */}
@@ -314,7 +317,7 @@ export function WelcomePage({ onDandisetLoaded }: WelcomePageProps) {
             </a>
           </Typography>
         ) : (
-          <List sx={{ maxHeight: 400, overflow: 'auto' }}>
+          <List sx={{ overflow: 'auto', flex: '1 1 auto', minHeight: 0 }}>
             {ownedDandisets.map((dandiset) => (
               <ListItemButton
                 key={dandiset.identifier}


### PR DESCRIPTION
Fixed the scrolling behavior on the welcome page:
- Removed conflicting overflow settings that created double scrollbars
- Redesigned the layout to use flexbox with proper constraints
- The outer container scrolls when needed while the inner list dynamically sizes to fit available space
- Prevents content from extending below the viewport on small screens