### PR TITLE
Make model name clickable to open settings

### DIFF
--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -188,7 +188,8 @@ export function ChatPanel() {
             label={chat.model.split("/")[1]}
             size="small"
             variant="outlined"
-            sx={{ fontSize: "0.7rem" }}
+            onClick={() => setSettingsOpen(true)}
+            sx={{ fontSize: "0.7rem", cursor: "pointer" }}
           />
           <Tooltip title="Download Chat">
             <span>


### PR DESCRIPTION
Clicking on the model name chip in the chat header now opens the settings dialog, providing quick access to change models or configure API keys.