### PR TITLE
DO NOT MERGE: Fix pending changes not showing in array tables

### DIFF
--- a/src/components/Metadata/GenericArrayTable.tsx
+++ b/src/components/Metadata/GenericArrayTable.tsx
@@ -16,7 +16,9 @@ import {
 import UndoIcon from '@mui/icons-material/Undo';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import AddIcon from '@mui/icons-material/Add';
 import { useMetadataContext } from '../../context/MetadataContext';
+import type { PendingChange } from '../../types/dandiset';
 
 interface GenericItem {
   schemaKey?: string;
@@ -27,12 +29,14 @@ interface GenericItem {
 
 interface GenericRowProps {
   item: GenericItem;
-  index: number;
+  originalItem: GenericItem | null;  // null if this is a new item
   path: string;
   columns: ColumnDef[];
   hasChange: boolean;
   hasChildChanges: boolean;
+  isNewItem: boolean;
   onRevert?: () => void;
+  getPendingChangeForPath: (path: string) => PendingChange | undefined;
 }
 
 interface ColumnDef {
@@ -41,7 +45,7 @@ interface ColumnDef {
   render?: (value: unknown, item: GenericItem) => React.ReactNode;
 }
 
-function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omit<GenericRowProps, 'index' | 'path'>) {
+function GenericRow({ item, originalItem, path, columns, hasChange, hasChildChanges, isNewItem, onRevert, getPendingChangeForPath }: GenericRowProps) {
   const [expanded, setExpanded] = useState(false);
   
   // Get extra fields not shown in columns
@@ -57,7 +61,7 @@ function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omi
   );
   
   const showExpand = extraFields.length > 0;
-  const rowHighlight = hasChange || hasChildChanges;
+  const rowHighlight = hasChange || hasChildChanges || isNewItem;
 
   return (
     <>
@@ -68,25 +72,60 @@ function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omi
         }}
       >
         <TableCell sx={{ py: 0.75, width: 40 }}>
-          {showExpand ? (
-            <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ p: 0.25 }}>
-              {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-            </IconButton>
-          ) : (
-            <Box sx={{ width: 24 }} />
-          )}
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {isNewItem && (
+              <Tooltip title="New item">
+                <AddIcon fontSize="small" sx={{ color: 'success.main', mr: 0.5 }} />
+              </Tooltip>
+            )}
+            {showExpand ? (
+              <IconButton size="small" onClick={() => setExpanded(!expanded)} sx={{ p: 0.25 }}>
+                {expanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </IconButton>
+            ) : (
+              !isNewItem && <Box sx={{ width: 24 }} />
+            )}
+          </Box>
         </TableCell>
-        {columns.map((col) => (
-          <TableCell key={col.key} sx={{ py: 0.75 }}>
-            {col.render 
-              ? col.render(item[col.key], item)
-              : formatValue(item[col.key])
-            }
-          </TableCell>
-        ))}
+        {columns.map((col) => {
+          const fieldPath = `${path}.${col.key}`;
+          const fieldChange = getPendingChangeForPath(fieldPath);
+          const displayValue = item[col.key];
+          // For diff display, use original item if available, otherwise check the pending change
+          const originalValue = originalItem ? originalItem[col.key] : (fieldChange ? fieldChange.oldValue : undefined);
+          const hasFieldChange = fieldChange !== undefined || (originalItem && originalItem[col.key] !== item[col.key]);
+          
+          return (
+            <TableCell key={col.key} sx={{ py: 0.75 }}>
+              <Box>
+                {/* Show old value crossed out if changed */}
+                {hasFieldChange && !isNewItem && originalValue !== undefined && originalValue !== null && originalValue !== displayValue && (
+                  <Box sx={{ mb: 0.25 }}>
+                    {col.render ? (
+                      <Box sx={{ opacity: 0.7, '& *': { textDecoration: 'line-through', color: 'error.main !important' } }}>
+                        {col.render(originalValue, originalItem || item)}
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.75rem' }}>
+                        {formatValueAsString(originalValue)}
+                      </Typography>
+                    )}
+                  </Box>
+                )}
+                {/* Show current/new value */}
+                <Box sx={{ '& *': { color: (hasFieldChange || isNewItem) ? 'success.dark' : undefined } }}>
+                  {col.render 
+                    ? col.render(displayValue, item)
+                    : formatValue(displayValue, hasFieldChange || isNewItem)
+                  }
+                </Box>
+              </Box>
+            </TableCell>
+          );
+        })}
         <TableCell sx={{ py: 0.75, width: 50 }}>
-          {(hasChange || hasChildChanges) && onRevert && (
-            <Tooltip title="Revert changes">
+          {(hasChange || hasChildChanges || isNewItem) && onRevert && (
+            <Tooltip title={isNewItem ? "Remove new item" : "Revert changes"}>
               <IconButton size="small" onClick={onRevert} color="warning" sx={{ p: 0.25 }}>
                 <UndoIcon fontSize="small" />
               </IconButton>
@@ -101,16 +140,33 @@ function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omi
               <Box sx={{ py: 1, pl: 6, pr: 2 }}>
                 <Table size="small" sx={{ backgroundColor: 'grey.50' }}>
                   <TableBody>
-                    {extraFields.map(([key, value]) => (
-                      <TableRow key={key}>
-                        <TableCell sx={{ width: 120, fontWeight: 500, color: 'text.secondary', border: 0, py: 0.5 }}>
-                          {formatLabel(key)}
-                        </TableCell>
-                        <TableCell sx={{ border: 0, py: 0.5 }}>
-                          {renderExpandedValue(value)}
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {extraFields.map(([key, value]) => {
+                      const fieldPath = `${path}.${key}`;
+                      const fieldChange = getPendingChangeForPath(fieldPath);
+                      const originalValue = originalItem ? originalItem[key] : (fieldChange?.oldValue ?? undefined);
+                      const hasFieldChange = fieldChange !== undefined || (originalItem && originalItem[key] !== value);
+                      
+                      return (
+                        <TableRow 
+                          key={key}
+                          sx={{ backgroundColor: (hasFieldChange || isNewItem) ? 'success.lighter' : 'transparent' }}
+                        >
+                          <TableCell sx={{ width: 120, fontWeight: 500, color: (hasFieldChange || isNewItem) ? 'primary.main' : 'text.secondary', border: 0, py: 0.5 }}>
+                            {formatLabel(key)}
+                          </TableCell>
+                          <TableCell sx={{ border: 0, py: 0.5 }}>
+                            {hasFieldChange && !isNewItem && originalValue !== undefined && originalValue !== null && originalValue !== value && (
+                              <Typography variant="body2" sx={{ textDecoration: 'line-through', color: 'error.main', fontSize: '0.8rem', mb: 0.25 }}>
+                                {renderExpandedValueString(originalValue)}
+                              </Typography>
+                            )}
+                            <Box sx={{ color: (hasFieldChange || isNewItem) ? 'success.dark' : 'text.primary' }}>
+                              {renderExpandedValue(value)}
+                            </Box>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               </Box>
@@ -122,14 +178,25 @@ function GenericRow({ item, columns, hasChange, hasChildChanges, onRevert }: Omi
   );
 }
 
-function formatValue(value: unknown): React.ReactNode {
+function formatValue(value: unknown, hasChange?: boolean): React.ReactNode {
+  const color = hasChange ? 'success.dark' : 'text.primary';
   if (value === null || value === undefined) return <Typography variant="body2" color="text.secondary">—</Typography>;
-  if (typeof value === 'string') return <Typography variant="body2">{value || '—'}</Typography>;
+  if (typeof value === 'string') return <Typography variant="body2" sx={{ color }}>{value || '—'}</Typography>;
   if (typeof value === 'boolean') return <Chip label={value ? 'Yes' : 'No'} size="small" sx={{ height: 20, fontSize: '0.7rem' }} />;
-  if (typeof value === 'number') return <Typography variant="body2">{value}</Typography>;
+  if (typeof value === 'number') return <Typography variant="body2" sx={{ color }}>{value}</Typography>;
   if (Array.isArray(value)) return <Typography variant="body2" color="text.secondary">[{value.length} items]</Typography>;
   if (typeof value === 'object') return <Typography variant="body2" color="text.secondary">{'{...}'}</Typography>;
-  return <Typography variant="body2">{String(value)}</Typography>;
+  return <Typography variant="body2" sx={{ color }}>{String(value)}</Typography>;
+}
+
+function formatValueAsString(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value || '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return String(value);
+  if (Array.isArray(value)) return `[${value.length} items]`;
+  if (typeof value === 'object') return '{...}';
+  return String(value);
 }
 
 function renderExpandedValue(value: unknown): React.ReactNode {
@@ -167,6 +234,27 @@ function renderExpandedValue(value: unknown): React.ReactNode {
   return String(value);
 }
 
+function renderExpandedValueString(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return String(value);
+  if (Array.isArray(value)) {
+    return value.map(item => 
+      typeof item === 'object' && item !== null
+        ? ('name' in item ? (item as { name: string }).name : JSON.stringify(item))
+        : String(item)
+    ).join(', ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([k, v]) => k !== 'schemaKey' && k !== 'id' && v !== null && v !== undefined)
+      .map(([k, v]) => `${formatLabel(k)}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+      .join(', ');
+  }
+  return String(value);
+}
+
 function formatLabel(key: string): string {
   // Convert camelCase to Title Case
   return key
@@ -177,15 +265,17 @@ function formatLabel(key: string): string {
 
 interface GenericArrayTableProps {
   path: string;
-  items: GenericItem[] | undefined | null;
+  items: GenericItem[] | undefined | null;  // Modified items (with pending changes applied)
+  originalItems: GenericItem[] | undefined | null;  // Original items from versionInfo
   columns: ColumnDef[];
   emptyMessage?: string;
 }
 
-export function GenericArrayTable({ path, items, columns, emptyMessage = 'No items' }: GenericArrayTableProps) {
+export function GenericArrayTable({ path, items, originalItems, columns, emptyMessage = 'No items' }: GenericArrayTableProps) {
   const { pendingChanges, removePendingChange, getPendingChangeForPath } = useMetadataContext();
 
   const displayItems = items || [];
+  const origItems = originalItems || [];
 
   if (displayItems.length === 0) {
     return (
@@ -216,6 +306,10 @@ export function GenericArrayTable({ path, items, columns, emptyMessage = 'No ite
             const hasChildChanges = pendingChanges.some(c => 
               c.path.startsWith(`${itemPath}.`)
             );
+            
+            // Check if this is a new item (index >= original items length)
+            const isNewItem = index >= origItems.length;
+            const originalItem = isNewItem ? null : origItems[index];
 
             const handleRevert = () => {
               removePendingChange(itemPath);
@@ -228,10 +322,14 @@ export function GenericArrayTable({ path, items, columns, emptyMessage = 'No ite
               <GenericRow
                 key={index}
                 item={item}
+                originalItem={originalItem}
+                path={itemPath}
                 columns={columns}
                 hasChange={hasDirectChange}
                 hasChildChanges={hasChildChanges}
-                onRevert={(hasDirectChange || hasChildChanges) ? handleRevert : undefined}
+                isNewItem={isNewItem}
+                onRevert={(hasDirectChange || hasChildChanges || isNewItem) ? handleRevert : undefined}
+                getPendingChangeForPath={getPendingChangeForPath}
               />
             );
           })}
@@ -244,12 +342,17 @@ export function GenericArrayTable({ path, items, columns, emptyMessage = 'No ite
 // Pre-configured tables for specific types
 
 export function AboutTable() {
-  const { versionInfo } = useMetadataContext();
+  const { versionInfo, getModifiedMetadata } = useMetadataContext();
   if (!versionInfo) return null;
 
+  // Get both original and modified items
+  const originalItems = versionInfo.metadata.about;
+  const modifiedMetadata = getModifiedMetadata();
+  const modifiedItems = modifiedMetadata?.about ?? originalItems;
+
   const columns: ColumnDef[] = [
-    { 
-      key: 'name', 
+    {
+      key: 'name',
       label: 'Name',
       render: (value) => (
         <Typography variant="body2" sx={{ fontWeight: 500 }}>
@@ -257,8 +360,8 @@ export function AboutTable() {
         </Typography>
       )
     },
-    { 
-      key: 'identifier', 
+    {
+      key: 'identifier',
       label: 'Identifier',
       render: (value) => (
         <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
@@ -266,15 +369,15 @@ export function AboutTable() {
         </Typography>
       )
     },
-    { 
-      key: 'schemaKey', 
+    {
+      key: 'schemaKey',
       label: 'Type',
       render: (value) => (
-        <Chip 
-          label={(value as string)?.replace('Type', '') || 'Unknown'} 
-          size="small" 
+        <Chip
+          label={(value as string)?.replace('Type', '') || 'Unknown'}
+          size="small"
           variant="outlined"
-          sx={{ height: 20, fontSize: '0.7rem' }} 
+          sx={{ height: 20, fontSize: '0.7rem' }}
         />
       )
     },
@@ -283,7 +386,8 @@ export function AboutTable() {
   return (
     <GenericArrayTable
       path="about"
-      items={versionInfo.metadata.about as GenericItem[]}
+      items={modifiedItems as GenericItem[]}
+      originalItems={originalItems as GenericItem[]}
       columns={columns}
       emptyMessage="No subject matter specified"
     />
@@ -291,12 +395,17 @@ export function AboutTable() {
 }
 
 export function EthicsApprovalTable() {
-  const { versionInfo } = useMetadataContext();
+  const { versionInfo, getModifiedMetadata } = useMetadataContext();
   if (!versionInfo) return null;
 
+  // Get both original and modified items
+  const originalItems = versionInfo.metadata.ethicsApproval;
+  const modifiedMetadata = getModifiedMetadata();
+  const modifiedItems = modifiedMetadata?.ethicsApproval ?? originalItems;
+
   const columns: ColumnDef[] = [
-    { 
-      key: 'identifier', 
+    {
+      key: 'identifier',
       label: 'Protocol Identifier',
       render: (value) => (
         <Typography variant="body2" sx={{ fontWeight: 500 }}>
@@ -309,7 +418,8 @@ export function EthicsApprovalTable() {
   return (
     <GenericArrayTable
       path="ethicsApproval"
-      items={versionInfo.metadata.ethicsApproval as GenericItem[]}
+      items={modifiedItems as GenericItem[]}
+      originalItems={originalItems as GenericItem[]}
       columns={columns}
       emptyMessage="No ethics approvals"
     />
@@ -317,12 +427,17 @@ export function EthicsApprovalTable() {
 }
 
 export function ProjectsTable() {
-  const { versionInfo } = useMetadataContext();
+  const { versionInfo, getModifiedMetadata } = useMetadataContext();
   if (!versionInfo) return null;
 
+  // Get both original and modified items
+  const originalItems = versionInfo.metadata.wasGeneratedBy;
+  const modifiedMetadata = getModifiedMetadata();
+  const modifiedItems = modifiedMetadata?.wasGeneratedBy ?? originalItems;
+
   const columns: ColumnDef[] = [
-    { 
-      key: 'name', 
+    {
+      key: 'name',
       label: 'Name',
       render: (value) => (
         <Typography variant="body2" sx={{ fontWeight: 500 }}>
@@ -330,8 +445,8 @@ export function ProjectsTable() {
         </Typography>
       )
     },
-    { 
-      key: 'identifier', 
+    {
+      key: 'identifier',
       label: 'Identifier',
       render: (value) => (
         <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
@@ -344,7 +459,8 @@ export function ProjectsTable() {
   return (
     <GenericArrayTable
       path="wasGeneratedBy"
-      items={versionInfo.metadata.wasGeneratedBy as GenericItem[]}
+      items={modifiedItems as GenericItem[]}
+      originalItems={originalItems as GenericItem[]}
       columns={columns}
       emptyMessage="No associated projects"
     />

--- a/src/components/Metadata/StringArrayField.tsx
+++ b/src/components/Metadata/StringArrayField.tsx
@@ -17,45 +17,57 @@ interface StringArrayFieldProps {
 }
 
 export function StringArrayField({ label, path, values, isUrl = false }: StringArrayFieldProps) {
-  const { getPendingChangeForPath, removePendingChange, pendingChanges } = useMetadataContext();
+  const { getPendingChangeForPath, removePendingChange, pendingChanges, getModifiedMetadata } = useMetadataContext();
   
   const pendingChange = getPendingChangeForPath(path);
   const hasChange = !!pendingChange;
   
   // Check for item-level changes (e.g., keywords.0)
-  const itemChanges = pendingChanges.filter(c => 
+  const itemChanges = pendingChanges.filter(c =>
     c.path.startsWith(`${path}.`) && !c.path.slice(path.length + 1).includes('.')
   );
   const hasItemChanges = itemChanges.length > 0;
   
-  const displayValues = hasChange 
+  // Get original and modified values to handle new items
+  const originalValues = values || [];
+  const modifiedMetadata = getModifiedMetadata();
+  const modifiedValues = modifiedMetadata ? (modifiedMetadata[path as keyof typeof modifiedMetadata] as string[] | undefined) : undefined;
+  
+  // Use modified values if available, otherwise fall back to values with pending changes
+  const displayValues = hasChange
     ? (pendingChange.newValue as string[] | null) || []
-    : values || [];
+    : (modifiedValues ?? originalValues);
+  
+  // Check if there are any new items beyond the original array length
+  const hasNewItems = displayValues.length > originalValues.length;
+  
+  // Has any kind of change
+  const hasAnyChange = hasChange || hasItemChanges || hasNewItems;
 
   const handleRevert = () => {
     removePendingChange(path);
     itemChanges.forEach(c => removePendingChange(c.path));
   };
 
-  const isEmpty = displayValues.length === 0 && !hasChange && !hasItemChanges;
+  const isEmpty = displayValues.length === 0 && !hasAnyChange;
 
   return (
-    <Box 
-      sx={{ 
-        display: 'flex', 
-        alignItems: 'flex-start', 
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
         py: 0.75,
-        backgroundColor: (hasChange || hasItemChanges) ? 'success.lighter' : 'transparent',
+        backgroundColor: hasAnyChange ? 'success.lighter' : 'transparent',
         px: 1,
         borderRadius: 1,
         mb: 0.5,
       }}
     >
-      <Typography 
-        variant="body2" 
-        sx={{ 
-          fontWeight: 500, 
-          color: (hasChange || hasItemChanges) ? 'primary.main' : 'text.secondary',
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 500,
+          color: hasAnyChange ? 'primary.main' : 'text.secondary',
           minWidth: 120,
           flexShrink: 0,
         }}
@@ -67,38 +79,49 @@ export function StringArrayField({ label, path, values, isUrl = false }: StringA
           <Typography variant="body2" color="text.secondary">—</Typography>
         ) : isUrl ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-            {displayValues.map((value, i) => (
-              <Link 
-                key={i} 
-                href={value} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                sx={{ fontSize: '0.85rem' }}
-              >
-                {value}
-              </Link>
-            ))}
+            {displayValues.map((value, i) => {
+              const isNewItem = i >= originalValues.length;
+              return (
+                <Link
+                  key={i}
+                  href={value}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    fontSize: '0.85rem',
+                    color: isNewItem ? 'success.dark' : 'primary.main',
+                  }}
+                >
+                  {value}
+                </Link>
+              );
+            })}
           </Box>
         ) : (
-          displayValues.map((value, i) => (
-            <Chip
-              key={i}
-              label={value}
-              size="small"
-              variant="outlined"
-              sx={{ 
-                height: 22, 
-                fontSize: '0.75rem',
-                backgroundColor: itemChanges.some(c => c.path === `${path}.${i}`) ? 'success.light' : undefined,
-              }}
-            />
-          ))
+          displayValues.map((value, i) => {
+            const isNewItem = i >= originalValues.length;
+            const hasItemChange = itemChanges.some(c => c.path === `${path}.${i}`);
+            return (
+              <Chip
+                key={i}
+                label={value}
+                size="small"
+                variant="outlined"
+                sx={{
+                  height: 22,
+                  fontSize: '0.75rem',
+                  backgroundColor: (hasItemChange || isNewItem) ? 'success.light' : undefined,
+                  borderColor: isNewItem ? 'success.main' : undefined,
+                }}
+              />
+            );
+          })
         )}
       </Box>
-      {(hasChange || hasItemChanges) && (
+      {hasAnyChange && (
         <Tooltip title="Revert changes">
-          <IconButton 
-            size="small" 
+          <IconButton
+            size="small"
             onClick={handleRevert}
             color="warning"
             sx={{ flexShrink: 0, ml: 1 }}


### PR DESCRIPTION
## Problem
Pending items weren't showing up in array tables (AboutTable, ContributorsTable, RelatedResourcesTable, etc.). The components only iterated over items from `versionInfo.metadata` (original data), missing any new items added via pending changes.

## Solution
Updated all array table components to use `getModifiedMetadata()` to include pending new items while preserving the ability to show diffs (old value crossed out, new value highlighted).

### Changes:

- **GenericArrayTable.tsx**: Added `originalItems` prop for diff comparison. Updated `GenericRow` to check pending changes for each field and show old/new values as diffs. New items display with a "+" icon. `AboutTable`, `EthicsApprovalTable`, `ProjectsTable` now use `getModifiedMetadata()`.

- **ContributorsTable.tsx**: Added `isNewItem` prop to `ContributorRow`. Uses `getModifiedMetadata()` to show new contributors with "+" icon and highlighting.

- **RelatedResourcesTable.tsx**: Added `isNewItem` prop to `ResourceRow`. Uses `getModifiedMetadata()` to show new resources with "+" icon and highlighting.

- **StringArrayField.tsx**: Uses `getModifiedMetadata()` to include new array items with success color highlighting.