### PR TITLE
Show loading spinner on dandiset page when loading from URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,16 +96,18 @@ function AppContent() {
     if (urlDandisetId && !versionInfo) {
       // Auto-load the dandiset from URL parameters (always use draft)
       const loadFromUrl = async () => {
+        // Set dandiset ID immediately so main layout shows with loading spinner
+        setDandisetId(urlDandisetId);
         setIsLoading(true);
         setError(null);
         try {
           const info = await fetchDandisetVersionInfo(urlDandisetId, 'draft', apiKey);
           setVersionInfo(info);
-          setDandisetId(urlDandisetId);
           setVersion('draft');
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to load dandiset from URL');
-          // Clear invalid URL params
+          // Clear dandiset ID and URL params on error
+          setDandisetId('');
           updateUrl(null);
         } finally {
           setIsLoading(false);

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -34,6 +34,7 @@ export function ChatPanel() {
     dandisetId,
     version,
     modifyMetadata,
+    isLoading,
   } = useMetadataContext();
 
   const {
@@ -231,26 +232,44 @@ export function ChatPanel() {
         }}
       >
         {!hasMetadata ? (
-          <Paper
-            elevation={0}
-            sx={{
-              p: 4,
-              textAlign: "center",
-              backgroundColor: "grey.50",
-              borderRadius: 2,
-              m: "auto",
-              maxWidth: 400,
-            }}
-          >
-            <SmartToyIcon sx={{ fontSize: 48, color: "grey.400", mb: 2 }} />
-            <Typography variant="h6" color="text.secondary" gutterBottom>
-              Load a Dandiset First
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Load a dandiset using the welcome page to start chatting with the
-              AI assistant about metadata.
-            </Typography>
-          </Paper>
+          isLoading ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                m: "auto",
+                gap: 2,
+              }}
+            >
+              <CircularProgress />
+              <Typography variant="body2" color="text.secondary">
+                Loading dandiset...
+              </Typography>
+            </Box>
+          ) : (
+            <Paper
+              elevation={0}
+              sx={{
+                p: 4,
+                textAlign: "center",
+                backgroundColor: "grey.50",
+                borderRadius: 2,
+                m: "auto",
+                maxWidth: 400,
+              }}
+            >
+              <SmartToyIcon sx={{ fontSize: 48, color: "grey.400", mb: 2 }} />
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                Load a Dandiset First
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Load a dandiset using the welcome page to start chatting with the
+                AI assistant about metadata.
+              </Typography>
+            </Paper>
+          )
         ) : allMessages.length === 0 ? (
           <Paper
             elevation={0}


### PR DESCRIPTION
When navigating to a dandiset via URL (e.g., `?dandiset=001471`), the app now immediately shows the dandiset page with loading spinners instead of staying on the welcome page during the load.

## Changes

- **App.tsx**: Set `dandisetId` immediately before fetching so main layout shows during loading
- **ChatPanel.tsx**: Display loading spinner when `isLoading` is true instead of "Load a Dandiset First" message

This improves UX by giving users immediate feedback that their dandiset is being loaded.