### PR TITLE
Add About dialog to app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
-import { Box, AppBar, Toolbar, Typography } from '@mui/material';
+import { Box, AppBar, Toolbar, Typography, IconButton } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
 import { MetadataProvider, useMetadataContext } from './context/MetadataContext';
 import logoIcon from '/logo-white.svg';
 import { MainLayout } from './components/Layout/MainLayout';
@@ -9,6 +10,7 @@ import { MetadataPanel } from './components/Metadata/MetadataPanel';
 import { WelcomePage } from './components/Welcome/WelcomePage';
 import { DandisetIndicator } from './components/Controls/DandisetIndicator';
 import { ApiKeyManager } from './components/Controls/ApiKeyManager';
+import AboutDialog from './components/About/AboutDialog';
 import { fetchDandisetVersionInfo } from './utils/api';
 
 // Create a custom theme with better colors for diffs
@@ -84,6 +86,8 @@ function AppContent() {
     setOriginalMetadata
   } = useMetadataContext();
 
+  const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
+
   useEffect(() => {
     if (versionInfo && versionInfo.metadata) {
       setOriginalMetadata(versionInfo.metadata);
@@ -143,6 +147,14 @@ function AppContent() {
             <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
               Dandiset Metadata Assistant
             </Typography>
+            <IconButton
+              color="inherit"
+              onClick={() => setAboutDialogOpen(true)}
+              size="small"
+              sx={{ mr: 1 }}
+            >
+              <InfoIcon />
+            </IconButton>
             <ApiKeyManager />
           </Toolbar>
         </AppBar>
@@ -151,6 +163,12 @@ function AppContent() {
         <Box sx={{ flex: 1, overflow: 'hidden' }}>
           <WelcomePage onDandisetLoaded={handleDandisetLoaded} />
         </Box>
+
+        {/* About Dialog */}
+        <AboutDialog
+          open={aboutDialogOpen}
+          onClose={() => setAboutDialogOpen(false)}
+        />
       </Box>
     );
   }
@@ -178,6 +196,14 @@ function AppContent() {
           <Box sx={{ flexGrow: 1 }}>
             <DandisetIndicator onChangeDandiset={handleChangeDandiset} />
           </Box>
+          <IconButton
+            color="inherit"
+            onClick={() => setAboutDialogOpen(true)}
+            size="small"
+            sx={{ mr: 1 }}
+          >
+            <InfoIcon />
+          </IconButton>
           <ApiKeyManager />
         </Toolbar>
       </AppBar>
@@ -192,6 +218,12 @@ function AppContent() {
           maxLeftWidth={75}
         />
       </Box>
+
+      {/* About Dialog */}
+      <AboutDialog
+        open={aboutDialogOpen}
+        onClose={() => setAboutDialogOpen(false)}
+      />
     </Box>
   );
 }

--- a/src/components/About/AboutDialog.tsx
+++ b/src/components/About/AboutDialog.tsx
@@ -1,0 +1,78 @@
+import { FunctionComponent } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Link,
+} from "@mui/material";
+import GitHubIcon from "@mui/icons-material/GitHub";
+
+interface AboutDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const AboutDialog: FunctionComponent<AboutDialogProps> = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>About Dandiset Metadata Assistant</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+          {/* Description */}
+          <Typography variant="body1">
+            A web application for viewing and editing DANDI Archive dandiset
+            metadata with AI assistance. Load a dandiset from the DANDI
+            Archive, view its metadata, and use the integrated AI chat and
+            manual tools to modify and improve your metadata.
+          </Typography>
+
+          <Typography variant="body1">
+            The application tracks changes with visual diffs, making it easy
+            to review modifications before committing them back to the archive.
+          </Typography>
+
+          {/* Authors */}
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Authors
+            </Typography>
+            <Typography variant="body2">
+              Jeremy Magland, Center for Computational Mathematics, Flatiron
+              Institute
+            </Typography>
+            <Typography variant="body2">
+              Ben Dichter, CatalystNeuro
+            </Typography>
+          </Box>
+
+          {/* GitHub Link */}
+          <Box>
+            <Link
+              href="https://github.com/magland/dandiset-metadata-assistant"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 1,
+                textDecoration: "none",
+              }}
+            >
+              <GitHubIcon fontSize="small" />
+              <Typography variant="body2">View on GitHub</Typography>
+            </Link>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AboutDialog;


### PR DESCRIPTION
Added an About button and dialog that displays:
- Application description
- Authors and affiliations
- Link to GitHub repository

The Info icon button appears in the AppBar (next to the API Key Manager) on both the welcome page and loaded dandiset views.