### PR TITLE
change default model to gpt-4.1-mini

### DIFF
--- a/src/chat/availableModels.ts
+++ b/src/chat/availableModels.ts
@@ -74,4 +74,4 @@ export const CHEAP_MODELS = [
   "moonshotai/kimi-k2-thinking"
 ];
 
-export const DEFAULT_MODEL = "openai/gpt-4.1-mini";
+export const DEFAULT_MODEL = "google/gemini-2.5-flash";


### PR DESCRIPTION
@bendichter 

I find that gpt-4.1-mini is a lot faster. Could you play around with it and see if it is sufficiently smart? If so, I suggest we switch the default.