### PR TITLE
Fix: Clear pending changes when switching dandisets

### DIFF
--- a/src/context/MetadataContext.tsx
+++ b/src/context/MetadataContext.tsx
@@ -140,6 +140,8 @@ export function MetadataProvider({ children }: { children: ReactNode }) {
 
   const setOriginalMetadata1 = useCallback((metadata: DandisetMetadata | null) => {
     setOriginalMetadata(metadata);
+    modifiedMetadataRef.current = null; // Reset modifications when loading new metadata
+    setMetadataRefreshCode((code) => code + 1);
   }, []);
 
   const setModifiedMetadata1 = useCallback((metadata: DandisetMetadata | null) => {


### PR DESCRIPTION
## Problem

When viewing a dandiset with pending changes and then switching to a different dandiset, the pending changes from the first dandiset were incorrectly carried over and appeared as pending changes for the new dandiset.

## Root Cause

The `modifiedMetadataRef` in MetadataContext persists across dandiset changes. When switching dandisets:
1. `clearModifications()` was called, setting `modifiedMetadataRef.current = originalMetadata` (still pointing to the old dandiset's data)
2. New dandiset loaded and updated `originalMetadata`
3. BUT `modifiedMetadataRef.current` retained the old dandiset's modified metadata

## Solution

Modified `setOriginalMetadata1()` in MetadataContext to reset `modifiedMetadataRef.current` to `null` when new metadata is loaded. This ensures modifications don't persist when switching between dandisets.

## Changes
- Updated `src/context/MetadataContext.tsx` to clear the modified metadata ref when setting new original metadata