### PR TITLE
Fix JSON Schema 2020-12 validation error

### DIFF
--- a/src/schemas/validateMetadata.ts
+++ b/src/schemas/validateMetadata.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import Ajv, { ErrorObject } from "ajv";
+import Ajv2020, { ErrorObject } from "ajv/dist/2020";
 import addFormats from "ajv-formats";
 import { fetchSchema, getCachedSchema } from "./schemaService";
 
-// Create and configure Ajv instance
-const ajv = new Ajv({
+// Create and configure Ajv instance with JSON Schema 2020-12 support
+// (the DANDI schema uses "$schema": "https://json-schema.org/draft/2020-12/schema")
+const ajv = new Ajv2020({
   allErrors: true, // Report all errors, not just the first one
   strict: false, // Disable strict mode to allow schema keywords like nskey, sameas, etc.
   validateFormats: true,


### PR DESCRIPTION
## Summary
- The DANDI schema declares `"$schema": "https://json-schema.org/draft/2020-12/schema"` but the code used the default `Ajv` constructor which only supports up to draft 2019-09
- Switched to `Ajv2020` from `ajv/dist/2020` (already bundled with ajv v8) to support draft 2020-12
- Fixes: `Error executing tool "propose_metadata_change": no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`

## Test plan
- [ ] Load a dandiset and use the chat to propose metadata changes
- [ ] Verify no schema validation errors appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)