### PR TITLE
Allow queuing messages while the agent is responding

### DIFF
--- a/src/chat/useChat.ts
+++ b/src/chat/useChat.ts
@@ -141,6 +141,7 @@ const useChat = (options: UseChatOptions) => {
   const [loadingInitialSuggestions, setLoadingInitialSuggestions] = useState<boolean>(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const initialSuggestionsRequestedForRef = useRef<string | null>(null);
+  const [messageQueue, setMessageQueue] = useState<string[]>([]);
 
   // Fetch DANDI metadata documentation on mount
   useEffect(() => {
@@ -406,6 +407,11 @@ Available tools:
 
   const submitUserMessage = useCallback(
     async (content: string) => {
+      if (responding || compressing) {
+        // Queue the message to be sent after the current response completes
+        setMessageQueue((prev) => [...prev, content]);
+        return;
+      }
       try {
         const userMessage: ChatMessage = { role: "user", content };
         const updatedChat = chatReducer(chat, {
@@ -420,8 +426,25 @@ Available tools:
         );
       }
     },
-    [chat, generateResponse]
+    [chat, generateResponse, responding, compressing]
   );
+
+  // Process queued messages when responding finishes
+  useEffect(() => {
+    if (!responding && !compressing && messageQueue.length > 0) {
+      const [nextMessage, ...rest] = messageQueue;
+      setMessageQueue(rest);
+      submitUserMessage(nextMessage);
+    }
+  }, [responding, compressing, messageQueue, submitUserMessage]);
+
+  const removeQueuedMessage = useCallback((index: number) => {
+    setMessageQueue((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const updateQueuedMessage = useCallback((index: number, content: string) => {
+    setMessageQueue((prev) => prev.map((msg, i) => i === index ? content : msg));
+  }, []);
 
   const setChatModel = useCallback((newModel: string) => {
     setChat((prev) => chatReducer(prev, { type: "set_model", model: newModel }));
@@ -432,6 +455,7 @@ Available tools:
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
+    setMessageQueue([]);
     setChat(emptyChat);
     setError(null);
     setPartialResponse(null);
@@ -740,6 +764,9 @@ ${plainTextConversation}`;
     tools,
     currentSuggestions,
     loadingInitialSuggestions,
+    messageQueue,
+    removeQueuedMessage,
+    updateQueuedMessage,
   };
 };
 

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   Chip,
   Tooltip,
   Button,
+  TextField,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
@@ -18,6 +19,7 @@ import RefreshIcon from "@mui/icons-material/Refresh";
 import StopIcon from "@mui/icons-material/Stop";
 import DownloadIcon from "@mui/icons-material/Download";
 import CompressIcon from "@mui/icons-material/Compress";
+import CloseIcon from "@mui/icons-material/Close";
 import { useMetadataContext } from "../../context/MetadataContext";
 import useChat from "../../chat/useChat";
 import { CHEAP_MODELS } from "../../chat/availableModels";
@@ -53,6 +55,9 @@ export function ChatPanel() {
     compressConversation,
     currentSuggestions,
     loadingInitialSuggestions,
+    messageQueue,
+    removeQueuedMessage,
+    updateQueuedMessage,
   } = useChat({
     originalMetadata,
     modifiedMetadata,
@@ -65,6 +70,8 @@ export function ChatPanel() {
   const [settingsOpen, setSettingsOpen] = useState<boolean>(false);
   const [compressDialogOpen, setCompressDialogOpen] = useState<boolean>(false);
   const [errorExpanded, setErrorExpanded] = useState<boolean>(false);
+  const [editingQueueIndex, setEditingQueueIndex] = useState<number | null>(null);
+  const [editingQueueText, setEditingQueueText] = useState<string>("");
   const conversationRef = useRef<HTMLDivElement>(null);
 
   // Get compression threshold from URL query parameter (for testing)
@@ -99,10 +106,10 @@ export function ChatPanel() {
   }, [allMessages]);
 
   const handleSubmit = useCallback(() => {
-    if (newPrompt.trim() === "" || responding || compressing || needsApiKey) return;
+    if (newPrompt.trim() === "" || compressing || needsApiKey) return;
     submitUserMessage(newPrompt.trim());
     setNewPrompt("");
-  }, [newPrompt, submitUserMessage, responding, compressing, needsApiKey]);
+  }, [newPrompt, submitUserMessage, compressing, needsApiKey]);
 
   const handleNewChat = useCallback(() => {
     clearChat();
@@ -523,12 +530,103 @@ export function ChatPanel() {
         </Box>
       )}
 
+      {/* Queued Messages */}
+      {messageQueue.length > 0 && (
+        <Box
+          sx={{
+            px: 2,
+            py: 1,
+            borderTop: 1,
+            borderColor: "divider",
+            backgroundColor: "grey.50",
+            display: "flex",
+            flexDirection: "column",
+            gap: 0.5,
+          }}
+        >
+          <Typography variant="caption" color="text.secondary">
+            Queued messages ({messageQueue.length}):
+          </Typography>
+          {messageQueue.map((msg, index) => (
+            <Box
+              key={index}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+              }}
+            >
+              <Chip
+                label={`${index + 1}`}
+                size="small"
+                color="primary"
+                variant="outlined"
+                sx={{ minWidth: 28, height: 22, fontSize: "0.7rem" }}
+              />
+              {editingQueueIndex === index ? (
+                <TextField
+                  value={editingQueueText}
+                  onChange={(e) => setEditingQueueText(e.target.value)}
+                  onBlur={() => {
+                    if (editingQueueText.trim()) {
+                      updateQueuedMessage(index, editingQueueText.trim());
+                    }
+                    setEditingQueueIndex(null);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      if (editingQueueText.trim()) {
+                        updateQueuedMessage(index, editingQueueText.trim());
+                      }
+                      setEditingQueueIndex(null);
+                    } else if (e.key === "Escape") {
+                      setEditingQueueIndex(null);
+                    }
+                  }}
+                  size="small"
+                  autoFocus
+                  fullWidth
+                  sx={{ "& .MuiInputBase-input": { fontSize: "0.8rem", py: 0.5 } }}
+                />
+              ) : (
+                <Typography
+                  variant="body2"
+                  sx={{
+                    flex: 1,
+                    fontSize: "0.8rem",
+                    cursor: "pointer",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                  onClick={() => {
+                    setEditingQueueIndex(index);
+                    setEditingQueueText(msg);
+                  }}
+                >
+                  {msg}
+                </Typography>
+              )}
+              <IconButton
+                size="small"
+                onClick={() => removeQueuedMessage(index)}
+                sx={{ p: 0.25 }}
+              >
+                <CloseIcon sx={{ fontSize: 16 }} />
+              </IconButton>
+            </Box>
+          ))}
+        </Box>
+      )}
+
       {/* Input Area */}
       <ChatInput
         value={newPrompt}
         onChange={setNewPrompt}
         onSubmit={handleSubmit}
-        disabled={responding || compressing || !hasMetadata || needsApiKey}
+        disabled={compressing || !hasMetadata || needsApiKey}
         placeholder={
           !hasMetadata
             ? "Load a dandiset first..."
@@ -536,7 +634,9 @@ export function ChatPanel() {
               ? "API key required..."
               : compressing
                 ? "Compressing conversation..."
-                : "Ask about metadata or request changes..."
+                : responding
+                  ? "Type a message to queue it..."
+                  : "Ask about metadata or request changes..."
         }
       />
 


### PR DESCRIPTION
## Summary
- Chat input stays enabled while the agent is responding — placeholder shows "Type a message to queue it..."
- Queued messages appear in a visible list above the input with numbered chips
- Click a queued message to edit it inline (Enter to save, Escape to cancel)
- Click the X to remove a queued message
- Messages are automatically submitted in order once the current response completes
- Queue is cleared when starting a new chat

## Test plan
- [ ] While the agent is thinking, type and submit a message — it should appear in the queue
- [ ] Click a queued message to edit it, press Enter to save
- [ ] Click X on a queued message to remove it
- [ ] Verify queued messages are submitted automatically when the agent finishes
- [ ] Verify "New Chat" clears the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)