### PR TITLE
Revamp welcome page with table view, pagination, and filters

### DIFF
--- a/src/chat/useChat.ts
+++ b/src/chat/useChat.ts
@@ -220,6 +220,7 @@ Your role is to help users understand and improve their dandiset metadata by:
 - ORCID format: https://orcid.org/0000-0000-0000-0000
 - ROR format: https://ror.org/XXXXXXX
 - To get funding/award information, use https://api.openalex.org/works/doi:[doi]?select=id,title,funders,awards
+- **IMPORTANT - VERIFY AUTHOR ORDER**: When adding contributors from a publication, ensure the order of authors matches the order listed in the paper. The OpenAlex API returns authors in publication order — preserve this order when adding contributors. After proposing contributor additions, verify that the author order in your proposal matches the order from the OpenAlex response. If the dandiset already has contributors listed in a different order, flag the discrepancy to the user.
 
 **SUGGESTED PROMPTS:**
 - You can include suggested follow-up prompts for the user in any of your responses


### PR DESCRIPTION
## Summary
- Replace dandiset list view with a sortable table (ID, name, modified date, validation status, stage columns)
- Add server-side pagination (25 per page) and "Only mine" / "Hide empty" client-side filters
- Make API key optional so all dandisets are browsable without authentication
- Support three validation statuses: Valid (green), Invalid (red), Pending (orange)
- Add author order verification instruction to chat system prompt

## Test plan
- [x] Verify table loads dandisets without an API key
- [x] Verify sorting by ID and modified date works
- [x] Verify "Hide empty" checkbox filters out dandisets with size 0 (enabled by default)
- [x] Verify "Only mine" checkbox appears after entering API key
- [x] Verify pagination controls work
- [x] Verify clicking a row loads the dandiset
- [x] Verify Valid/Invalid/Pending status chips display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)