### PR TITLE
Require tool-based lookup for all ROR, ORCID, and ontology IDs

### DIFF
--- a/src/chat/useChat.ts
+++ b/src/chat/useChat.ts
@@ -206,6 +206,9 @@ Your role is to help users understand and improve their dandiset metadata by:
 - If the fetch_url tool fails or returns an error, inform the user about the failure and do not proceed with fabricated data.
 - Only propose metadata changes based on information you have actually retrieved or that exists in the current metadata.
 
+**MANDATORY SEARCH FOR IDs:**
+- Before proposing any ROR, ORCID, or Ontology identifier, you MUST perform a search using the provided tools. You are prohibited from using an ID from your internal training data.
+
 **SUBJECT MATTER ANNOTATIONS (about field):**
 - When users mention brain regions, anatomical structures, diseases, disorders, or cognitive concepts, use the lookup_ontology_term tool to find validated ontology terms.
 - NEVER guess or fabricate ontology identifiers (UBERON, DOID, Cognitive Atlas, etc.) - always use lookup_ontology_term to get the correct URI.


### PR DESCRIPTION
## Summary
- Adds a mandatory search instruction to the AI system prompt
- Prohibits the AI from using ROR, ORCID, or ontology identifiers from its internal training data
- All identifiers must be looked up using the provided tools (fetch_url, lookup_ontology_term) before being proposed

## Test plan
- [ ] Verify the AI uses `lookup_ontology_term` before proposing any ontology URI
- [ ] Verify the AI fetches from OpenAlex/ORCID API before proposing ORCID identifiers
- [ ] Verify the AI fetches from ROR API before proposing ROR identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)