### PR TITLE
Fix TypeScript build error in SectionDisplay prop type

### DIFF
--- a/src/components/Metadata/EditableMetadataView.tsx
+++ b/src/components/Metadata/EditableMetadataView.tsx
@@ -31,6 +31,7 @@ import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import { useMetadataContext } from '../../context/MetadataContext';
 import { computeDelta, deltaToChanges } from '../../core/metadataDiff';
+import type { MetadataOperationType } from '../../core/metadataOperations';
 import { EditableTextField } from './EditableTextField';
 import { EditableKeywordsList } from './EditableKeywordsList';
 import { EditableLicenseSelect, LICENSE_OPTIONS } from './EditableLicenseSelect';
@@ -698,7 +699,7 @@ function SectionDisplay({
   isFieldModified: (key: string) => boolean;
   revertField: (key: string) => void;
   onEditField: (key: string, value: unknown) => { success: boolean; error?: string };
-  modifyMetadata: (operation: string, path: string, value?: unknown) => { success: boolean; error?: string };
+  modifyMetadata: (operation: MetadataOperationType, path: string, value?: unknown) => { success: boolean; error?: string };
 }) {
   const SectionIcon = section.icon;
   


### PR DESCRIPTION
## Summary
- The `SectionDisplay` component declared `modifyMetadata`'s `operation` parameter as `string`, but the function provided by `MetadataContext` uses `MetadataOperationType` (`'set' | 'delete' | 'insert' | 'append'`). This type mismatch caused the TypeScript build to fail.
- Imported `MetadataOperationType` and updated the prop type to match, fixing the build.

## Test plan
- [x] `npm run build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)