### PR TITLE
Prevent oversized tool results from bricking the chat

### DIFF
--- a/src/chat/processCompletion.ts
+++ b/src/chat/processCompletion.ts
@@ -8,6 +8,28 @@ import { parseCompletionStream } from "./parseCompletionStream";
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 10000; // 10 seconds (rate limit is 10 req/min)
 
+// Hard cap on the size of a single tool-result message. OpenRouter rejects any
+// message over 100000 characters, and once an oversized message is in the
+// conversation history every subsequent request fails identically — permanently
+// bricking the chat. Individual tools should keep their output small, but this is
+// a last line of defense that applies to ALL tools (current and future).
+const MAX_TOOL_RESULT_CHARS = 90000;
+
+/**
+ * Clamp a tool-result string to a size the model provider will accept, replacing
+ * the overflow with a notice the model can understand and act on.
+ */
+const clampToolResult = (content: string): string => {
+  if (content.length <= MAX_TOOL_RESULT_CHARS) return content;
+  const keep = MAX_TOOL_RESULT_CHARS - 500; // headroom for the notice
+  return (
+    content.substring(0, keep) +
+    `\n\n[Tool result truncated: it was ${content.length} characters, which exceeds the ` +
+    `${MAX_TOOL_RESULT_CHARS}-character limit for a single message. Narrow the request ` +
+    `(e.g. fewer results, a more specific query, or a dedicated tool) to get complete data.]`
+  );
+};
+
 /**
  * Sleep for a given number of milliseconds
  */
@@ -211,7 +233,7 @@ const processCompletion = async (
       }
       ret.push({
         role: "tool",
-        content: result,
+        content: clampToolResult(result),
         tool_call_id: toolCallId,
       });
       onPartialResponse([...ret]);

--- a/src/chat/tools/fetchUrl.ts
+++ b/src/chat/tools/fetchUrl.ts
@@ -124,11 +124,25 @@ export const fetchUrlTool: QPTool = {
         (domain) => hostname === domain || hostname.endsWith("." + domain)
       );
 
-      // For OpenAlex works API, automatically add select parameter to reduce response size
+      // For OpenAlex works API, automatically constrain the response size.
+      // A multi-result search (/works?search=...) returns 25 works each with a
+      // full author list, which can easily exceed the model provider's per-message
+      // limit. Distinguish a list query from a single-work lookup (/works/<id>).
       let finalUrl = url;
-      if (hostname === "api.openalex.org" && parsedUrl.pathname.startsWith("/works") && !parsedUrl.search.includes("select=")) {
+      if (hostname === "api.openalex.org" && parsedUrl.pathname.replace(/\/$/, "") === "/works") {
+        const params = new URLSearchParams(parsedUrl.search);
+        if (!params.has("select")) {
+          // Lean fields for discovery — NO authorships (the bulky field). The model
+          // should follow up with import_contributors_from_doi once it has a DOI.
+          params.set("select", "id,doi,title,display_name,publication_year");
+        }
+        if (!params.has("per_page") && !params.has("per-page")) {
+          params.set("per_page", "3");
+        }
+        finalUrl = `${parsedUrl.origin}${parsedUrl.pathname}?${params.toString()}`;
+      } else if (hostname === "api.openalex.org" && parsedUrl.pathname.startsWith("/works/") && !parsedUrl.search.includes("select=")) {
+        // Single-work lookup: full metadata is fine (one work, bounded size).
         const separator = parsedUrl.search ? "&" : "?";
-        // Select only fields useful for metadata extraction
         finalUrl = `${url}${separator}select=id,doi,title,display_name,authorships,publication_year,publication_date,funders,keywords`;
       }
 
@@ -167,9 +181,11 @@ export const fetchUrlTool: QPTool = {
         content = extractTextFromHtml(html);
       }
 
-      // Truncate if too long (to avoid overwhelming the context)
-      // 25000 chars accommodates most OpenAlex responses with full authorship data
-      const maxLength = 250000;
+      // Truncate if too long (to avoid overwhelming the context).
+      // Must stay well under the model provider's hard per-message limit
+      // (OpenRouter rejects messages over 100000 chars); leave headroom for the
+      // JSON wrapper this result is embedded in.
+      const maxLength = 75000;
       const truncated = content.length > maxLength;
       const finalContent = truncated
         ? content.substring(0, maxLength) + "\n\n[Content truncated due to length...]"

--- a/src/chat/tools/importContributorsFromDoi.ts
+++ b/src/chat/tools/importContributorsFromDoi.ts
@@ -1,0 +1,238 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { QPTool, ToolExecutionContext } from "../types";
+
+/**
+ * Deterministic tool that fetches OpenAlex authorship data for a DOI
+ * and converts it to dandiset contributor format.
+ *
+ * This avoids LLM "context rot" when processing large author lists —
+ * the mapping is done in code, not by the model.
+ */
+
+interface OpenAlexAffiliation {
+  display_name?: string;
+  ror?: string;
+}
+
+interface OpenAlexAuthorship {
+  author_position?: string;
+  author?: {
+    display_name?: string;
+    orcid?: string;
+  };
+  institutions?: OpenAlexAffiliation[];
+}
+
+interface DandiContributor {
+  name: string;
+  schemaKey: "Person";
+  roleName: string[];
+  includeInCitation: boolean;
+  identifier?: string;
+  affiliation?: {
+    name: string;
+    schemaKey: "Affiliation";
+    identifier?: string;
+  }[];
+}
+
+/**
+ * Convert "First Middle Last" to "Last, First Middle"
+ */
+function toLastFirst(displayName: string): string {
+  const parts = displayName.trim().split(/\s+/);
+  if (parts.length <= 1) return displayName.trim();
+  const last = parts[parts.length - 1];
+  const rest = parts.slice(0, -1).join(" ");
+  return `${last}, ${rest}`;
+}
+
+/**
+ * Extract bare ORCID ID from a URL like "https://orcid.org/0000-0002-1234-5678".
+ * The DANDI schema expects just the bare ID (e.g., "0000-0002-1234-5678"), not a URL.
+ */
+function normalizeOrcid(orcidRaw: string): string | undefined {
+  if (!orcidRaw) return undefined;
+  const bare = orcidRaw.replace(/^https?:\/\/orcid\.org\//, "");
+  if (/^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/.test(bare)) {
+    return bare;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize a ROR URL to its canonical form.
+ */
+function normalizeRor(rorRaw: string): string | undefined {
+  if (!rorRaw) return undefined;
+  // Accept https://ror.org/XXXXX
+  if (/^https?:\/\/ror\.org\/\w+$/.test(rorRaw)) {
+    return rorRaw.replace(/^http:/, "https:");
+  }
+  return undefined;
+}
+
+function convertAuthorship(authorship: OpenAlexAuthorship): DandiContributor {
+  const author = authorship.author || {};
+  const name = toLastFirst(author.display_name || "Unknown");
+
+  const contributor: DandiContributor = {
+    name,
+    schemaKey: "Person",
+    roleName: ["dcite:Author"],
+    includeInCitation: true,
+  };
+
+  // ORCID
+  if (author.orcid) {
+    const orcid = normalizeOrcid(author.orcid);
+    if (orcid) {
+      contributor.identifier = orcid;
+    }
+  }
+
+  // Affiliations
+  if (authorship.institutions && authorship.institutions.length > 0) {
+    contributor.affiliation = authorship.institutions
+      .filter((inst) => inst.display_name)
+      .map((inst) => {
+        const aff: DandiContributor["affiliation"] extends (infer T)[] | undefined ? T : never = {
+          name: inst.display_name!,
+          schemaKey: "Affiliation" as const,
+        };
+        if (inst.ror) {
+          const ror = normalizeRor(inst.ror);
+          if (ror) {
+            aff.identifier = ror;
+          }
+        }
+        return aff;
+      });
+    if (contributor.affiliation.length === 0) {
+      delete contributor.affiliation;
+    }
+  }
+
+  return contributor;
+}
+
+export const importContributorsFromDoiTool: QPTool = {
+  toolFunction: {
+    name: "import_contributors_from_doi",
+    description:
+      "Deterministically import all contributors (authors) from a publication DOI using OpenAlex. " +
+      "Returns properly formatted dandiset contributor objects with names, ORCIDs, and affiliations. " +
+      "Author order is preserved exactly as returned by OpenAlex. " +
+      "Use this tool instead of manually parsing OpenAlex author data.",
+    parameters: {
+      type: "object",
+      properties: {
+        doi: {
+          type: "string",
+          description:
+            'The DOI of the publication (e.g., "10.1016/j.neuron.2016.12.011"). Can include or omit the "https://doi.org/" prefix.',
+        },
+      },
+      required: ["doi"],
+    },
+  },
+
+  execute: async (
+    params: { doi: string },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _context: ToolExecutionContext,
+  ) => {
+    let { doi } = params;
+
+    // Strip URL prefix if provided
+    doi = doi.replace(/^https?:\/\/doi\.org\//, "");
+
+    const apiUrl = `https://api.openalex.org/works/doi:${doi}?select=id,doi,title,display_name,authorships`;
+
+    try {
+      const response = await fetch(apiUrl, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        return {
+          result: JSON.stringify({
+            success: false,
+            error: `OpenAlex API returned HTTP ${response.status}. The DOI "${doi}" may not be indexed.`,
+          }),
+        };
+      }
+
+      const data = await response.json();
+      const authorships: OpenAlexAuthorship[] = data.authorships || [];
+
+      if (authorships.length === 0) {
+        return {
+          result: JSON.stringify({
+            success: true,
+            doi,
+            title: data.title || data.display_name,
+            contributors: [],
+            message: "No authorships found in OpenAlex for this DOI.",
+          }),
+        };
+      }
+
+      const contributors = authorships.map(convertAuthorship);
+
+      return {
+        result: JSON.stringify({
+          success: true,
+          doi,
+          title: data.title || data.display_name,
+          totalAuthors: contributors.length,
+          contributors,
+          message:
+            `Successfully imported ${contributors.length} contributors from OpenAlex. ` +
+            `Author order is preserved exactly as listed in the publication. ` +
+            `Use propose_metadata_change to append these to the contributor array.`,
+        }),
+      };
+    } catch (error) {
+      return {
+        result: JSON.stringify({
+          success: false,
+          error: `Failed to fetch from OpenAlex: ${error instanceof Error ? error.message : "Unknown error"}`,
+          doi,
+        }),
+      };
+    }
+  },
+
+  getDetailedDescription: () => {
+    return `Use this tool to import contributors from a publication DOI via OpenAlex.
+
+**This tool deterministically converts OpenAlex author data to dandiset contributor format.**
+It guarantees:
+- All authors are included
+- Author order matches the publication exactly
+- ORCID identifiers are correctly formatted
+- Institutional affiliations with ROR IDs are mapped
+- Name format is "Last, First" as required by DANDI
+
+**Usage:**
+- Provide the DOI of the publication
+- The tool returns an array of contributor objects ready for use with propose_metadata_change
+
+**Example:**
+{ "doi": "10.1016/j.neuron.2016.12.011" }
+
+**After calling this tool**, use propose_metadata_change to append each contributor:
+{ "changes": [
+    { "operation": "append", "path": "contributor", "value": <contributor_object> },
+    ...
+  ]
+}
+
+**Notes:**
+- ORCIDs and ROR IDs from OpenAlex are included as-is (they come from OpenAlex's curated data)
+- If the dandiset already has contributors, compare the returned list with existing ones before adding
+- The first and last authors may need additional roles (e.g., dcite:ContactPerson for corresponding author)`;
+  },
+};

--- a/src/chat/useChat.ts
+++ b/src/chat/useChat.ts
@@ -6,6 +6,7 @@ import { DEFAULT_MODEL, AVAILABLE_MODELS } from "./availableModels";
 import { proposeMetadataChangeTool } from "./tools/proposeMetadataChange";
 import { fetchUrlTool } from "./tools/fetchUrl";
 import { lookupOntologyTermTool } from "./tools/lookupOntologyTerm";
+import { importContributorsFromDoiTool } from "./tools/importContributorsFromDoi";
 import { fetchSchema } from "../schemas/schemaService";
 import { parseSuggestions } from "./parseSuggestions";
 import { getStoredOpenRouterApiKey } from "./apiKeyStorage";
@@ -176,7 +177,7 @@ const useChat = (options: UseChatOptions) => {
     loadSchema();
   }, [dandisetSchema]);
 
-  const tools: QPTool[] = useMemo(() => [proposeMetadataChangeTool, fetchUrlTool, lookupOntologyTermTool], []);
+  const tools: QPTool[] = useMemo(() => [proposeMetadataChangeTool, fetchUrlTool, lookupOntologyTermTool, importContributorsFromDoiTool], []);
 
   const toolExecutionContext: ToolExecutionContext = useMemo(
     () => ({
@@ -218,14 +219,12 @@ Your role is to help users understand and improve their dandiset metadata by:
 - If multiple matches are found, present the options to the user and let them choose the most appropriate term.
 
 **CONTRIBUTOR INFORMATION FROM PUBLICATIONS:**
-- When adding contributors from a paper with a DOI, use the OpenAlex API to get detailed author information.
-- Fetch from: https://api.openalex.org/works/doi:{DOI} (e.g., https://api.openalex.org/works/doi:10.1016/j.neuron.2016.12.011)
-- The OpenAlex response includes authorships with: author name, ORCID identifier, and institutional affiliations with ROR IDs.
-- Use this data to populate contributor fields including: name, identifier (ORCID URL), and affiliation (with ROR identifier).
-- ORCID format: https://orcid.org/0000-0000-0000-0000
-- ROR format: https://ror.org/XXXXXXX
-- To get funding/award information, use https://api.openalex.org/works/doi:[doi]?select=id,title,funders,awards
-- **IMPORTANT - VERIFY AUTHOR ORDER**: When adding contributors from a publication, ensure the order of authors matches the order listed in the paper. The OpenAlex API returns authors in publication order — preserve this order when adding contributors. After proposing contributor additions, verify that the author order in your proposal matches the order from the OpenAlex response. If the dandiset already has contributors listed in a different order, flag the discrepancy to the user.
+- When adding contributors from a paper with a DOI, use the import_contributors_from_doi tool. This tool deterministically converts OpenAlex authorship data into properly formatted dandiset contributor objects, guaranteeing correct author order, name formatting, ORCIDs, and affiliations.
+- Do NOT manually parse OpenAlex authorship JSON — always use import_contributors_from_doi instead.
+- After calling import_contributors_from_doi, use propose_metadata_change to append the returned contributors to the contributor array.
+- If the dandiset already has contributors, compare the imported list with existing ones and ask the user how to reconcile differences.
+- The first and last authors may need additional roles (e.g., dcite:ContactPerson for corresponding author — ask the user).
+- To get funding/award information, use fetch_url with https://api.openalex.org/works/doi:[doi]?select=id,title,funders,awards
 
 **SUGGESTED PROMPTS:**
 - You can include suggested follow-up prompts for the user in any of your responses


### PR DESCRIPTION
## Problem

A real session on dandiset 001836 died and could not recover. `fetch_url` fetched an OpenAlex search response (`/works?search=…`) that came back as **270,074 characters** — over OpenRouter's hard **100,000-char per-message limit**:

```
Error: OpenRouter API error: Message 10 too large: 270074 characters (max: 100000)
```

Once that oversized message was in the conversation history, every subsequent request re-sent it and failed identically, so the user's "try again" hit the same wall. The chat was permanently bricked.

Root cause: `fetchUrl`'s truncation cap was `250000` — 2.5× the provider limit — so a large response sailed past truncation *and* past what OpenRouter accepts.

## Fixes

1. **`fetchUrl`: cap truncation at 75,000 chars** (was 250,000). Stays safely under the 100,000 provider limit.
2. **`fetchUrl`: constrain OpenAlex search queries.** A list query (`/works?search=…`) now gets `per_page=3` and a lean `select` that omits the bulky `authorships` field (the field that produced the 270 KB payload). A single-work lookup (`/works/<id>`) still returns full metadata since one work is bounded in size.
3. **`processCompletion`: add `clampToolResult()`** — a provider-independent hard guard capping *every* `role: "tool"` message at 90,000 chars before it enters history. Belt-and-suspenders: no current or future tool can brick a conversation, even if its own truncation fails.
4. **Add `import_contributors_from_doi` tool** for deterministic, bounded contributor import once a DOI is known, with the system prompt steered to use it instead of hand-parsing OpenAlex JSON.

## Testing

- `npx tsc --noEmit` passes.
- `npx eslint` on changed files clean (one pre-existing unused-disable warning, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)